### PR TITLE
ci/sign: wait as long as possible for approval

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -494,9 +494,7 @@ jobs:
           artifact-configuration-slug: stage1
           github-artifact-id: ${{ steps.stage.outputs.artifact_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-for-completion-timeout-in-seconds: 9000
-          service-unavailable-timeout-in-seconds: 9000
-          download-signed-artifact-timeout-in-seconds: 9000
+          wait-for-completion-timeout-in-seconds: 90000
           output-artifact-directory: signed
       - name: Copy signed binaries
         run: Copy-Item -Path "signed\*" -Destination "C:\helium-windows\build\src\out\Default\" -Recurse
@@ -519,9 +517,7 @@ jobs:
           artifact-configuration-slug: stage2
           github-artifact-id: ${{ steps.stage2.outputs.artifact_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-for-completion-timeout-in-seconds: 9000
-          service-unavailable-timeout-in-seconds: 9000
-          download-signed-artifact-timeout-in-seconds: 9000
+          wait-for-completion-timeout-in-seconds: 90000
           output-artifact-directory: signed
       - name: Copy signed installer
         run: Copy-Item -Path "signed\mini_installer.exe" -Destination "C:\helium-windows\build\src\out\Default\"
@@ -1053,9 +1049,7 @@ jobs:
           artifact-configuration-slug: stage1
           github-artifact-id: ${{ steps.stage.outputs.artifact_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-for-completion-timeout-in-seconds: 9000
-          service-unavailable-timeout-in-seconds: 9000
-          download-signed-artifact-timeout-in-seconds: 9000
+          wait-for-completion-timeout-in-seconds: 90000
           output-artifact-directory: signed
       - name: Copy signed binaries
         run: Copy-Item -Path "signed\*" -Destination "C:\helium-windows\build\src\out\Default\" -Recurse
@@ -1079,9 +1073,7 @@ jobs:
           artifact-configuration-slug: stage2
           github-artifact-id: ${{ steps.stage2.outputs.artifact_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-for-completion-timeout-in-seconds: 9000
-          service-unavailable-timeout-in-seconds: 9000
-          download-signed-artifact-timeout-in-seconds: 9000
+          wait-for-completion-timeout-in-seconds: 90000
           output-artifact-directory: signed
       - name: Copy signed installer
         run: Copy-Item -Path "signed\mini_installer.exe" -Destination "C:\helium-windows\build\src\out\Default\"

--- a/.github/workflows/main.yml.j2
+++ b/.github/workflows/main.yml.j2
@@ -90,9 +90,7 @@ jobs:
           artifact-configuration-slug: stage1
           github-artifact-id: ${{ steps.stage.outputs.artifact_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-for-completion-timeout-in-seconds: 9000
-          service-unavailable-timeout-in-seconds: 9000
-          download-signed-artifact-timeout-in-seconds: 9000
+          wait-for-completion-timeout-in-seconds: 90000
           output-artifact-directory: signed
       - name: Copy signed binaries
         run: Copy-Item -Path "signed\*" -Destination "C:\helium-windows\build\src\out\Default\" -Recurse
@@ -118,9 +116,7 @@ jobs:
           artifact-configuration-slug: stage2
           github-artifact-id: ${{ steps.stage2.outputs.artifact_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-for-completion-timeout-in-seconds: 9000
-          service-unavailable-timeout-in-seconds: 9000
-          download-signed-artifact-timeout-in-seconds: 9000
+          wait-for-completion-timeout-in-seconds: 90000
           output-artifact-directory: signed
       - name: Copy signed installer
         run: Copy-Item -Path "signed\mini_installer.exe" -Destination "C:\helium-windows\build\src\out\Default\"


### PR DESCRIPTION
use defaults for everything else, we don't really care or expect those to take longer than expected