### PR TITLE
ci/stage: pin httplib2 to 0.22.0

### DIFF
--- a/.github/actions/stage/index.js
+++ b/.github/actions/stage/index.js
@@ -51,7 +51,7 @@ async function run() {
         args.push('--do-package')
     }
 
-    await exec.exec('python', ['-m', 'pip', 'install', 'httplib2', 'Pillow'], {
+    await exec.exec('python', ['-m', 'pip', 'install', 'httplib2==0.22.0', 'Pillow'], {
         cwd: 'C:\\helium-windows',
         ignoreReturnCode: true
     });


### PR DESCRIPTION
because socks in the latest version are currently broken and unusable for gclient