### PR TITLE
chore: remove signpath policy

### DIFF
--- a/.signpath/policies/helium-chromium/release-signing.yml
+++ b/.signpath/policies/helium-chromium/release-signing.yml
@@ -1,5 +1,0 @@
-github-policies:
-  runners:
-    allowed_groups:
-      - 'GitHub Actions'
-      - 'Default'


### PR DESCRIPTION
we don't use signpath anymore