### PR TITLE
package: use .packed.7z, disable installer compression

### DIFF
--- a/installer/helium.nsi
+++ b/installer/helium.nsi
@@ -9,7 +9,7 @@
 ;   VERSION    - Helium version string (e.g., 0.10.4.1)
 ;   ARCH       - Target architecture (x64 or arm64)
 ;   SETUP_EXE  - Path to setup.exe
-;   HELIUM_7Z  - Path to helium.7z (uncompressed; NSIS handles compression)
+;   HELIUM_7Z  - Path to helium.7z
 ;   ICON_FILE  - Path to helium .ico file
 ;   OUTPUT_FILE - Output installer .exe path
 ;   LICENSE_FILE - Path to LICENSE file
@@ -32,7 +32,7 @@ Name "${PRODUCT_NAME} ${VERSION}"
 OutFile "${OUTPUT_FILE}"
 Unicode true
 ManifestDPIAware true
-SetCompressor /SOLID lzma
+SetCompress off
 RequestExecutionLevel user
 ShowInstDetails show
 
@@ -185,7 +185,7 @@ Section "Install" SecInstall
   File /oname=helium.7z "${HELIUM_7Z}"
 
   ; Build setup.exe command line
-  StrCpy $0 '"$TEMP\helium_install\setup.exe" --uncompressed-archive="$TEMP\helium_install\helium.7z" --do-not-launch-chrome'
+  StrCpy $0 '"$TEMP\helium_install\setup.exe" --install-archive="$TEMP\helium_install\helium.7z" --do-not-launch-chrome'
 
   ${If} $InstallType == "system"
     StrCpy $0 '$0 --system-level'

--- a/package.py
+++ b/package.py
@@ -54,7 +54,7 @@ def _build_nsis_installer(version, arch, build_outputs, output_file):
         f'-DVERSION={version}',
         f'-DARCH={arch}',
         f'-DSETUP_EXE={build_outputs / "setup.exe"}',
-        f'-DHELIUM_7Z={build_outputs / "helium.7z"}',
+        f'-DHELIUM_7Z={build_outputs / "helium.packed.7z"}',
         f'-DICON_FILE={_ICON_PATH}',
         f'-DOUTPUT_FILE={output_file}',
         f'-DLICENSE_FILE={_ROOT_DIR / "LICENSE"}',


### PR DESCRIPTION
installer lzma + 7z plain - 42.54s, 134 MB
installer zlib + 7z plain - 23.57s, 182 MB
installer zlib + 7z lzma - 19.06s, 115 MB
installer plain + 7z lzma - 17.24s, 118 MB

fixes #187