### PR TITLE
build.py: use -products * with vswhere to support VS Build Tools

### DIFF
--- a/build.py
+++ b/build.py
@@ -48,7 +48,7 @@ def _get_vcvars_path(name='64'):
     """
     vswhere_exe = '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe'
     result = subprocess.run(
-        '"{}" -prerelease -latest -property installationPath'.format(vswhere_exe),
+        '"{}" -products * -prerelease -latest -property installationPath'.format(vswhere_exe),
         shell=True,
         check=True,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
- [x] An issue exists where the maintainers agreed that this should be implemented.
      If such issue did not exist before, I opened one.
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.
- [x] The pull request contents are only relevant to the Windows platform, and can in
      no way be applied to other platforms.

---

Fix `build.py` failing to locate `vcvars64.bat` when VS Build Tools is installed instead of the full VS IDE.

`vswhere.exe` was called without `-products *`, causing it to silently ignore `Microsoft.VisualStudio.Product.BuildTools` installations and return an empty path. Adding `-products *` makes it discover all VS product types, matching how Chromium's depot_tools handles the same lookup.

Fixes https://github.com/imputnet/helium-windows/issues/214
