### PR TITLE
helium/windows: winsparkle updater

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -434,6 +434,20 @@ jobs:
           description: Helium
           description-url: https://github.com/imputnet/helium-windows
 
+      # we want a different description here, so sign it separately again
+      - name: Sign Helium update helper
+        uses: azure/artifact-signing-action@v1
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_SIGNING_CERTIFICATE_NAME }}
+          files: C:\helium-windows\build\src\out\Default\helium_update_helper.exe
+          description: Helium Update Helper
+          description-url: https://github.com/imputnet/helium-windows
+
       - name: Build Helium installer and package
         id: stage2
         uses: ./.github/actions/stage
@@ -889,6 +903,20 @@ jobs:
           certificate-profile-name: ${{ secrets.AZURE_SIGNING_CERTIFICATE_NAME }}
           files: ${{ steps.stage.outputs.files-to-sign }}
           description: Helium
+          description-url: https://github.com/imputnet/helium-windows
+
+      # we want a different description here, so sign it separately again
+      - name: Sign Helium update helper
+        uses: azure/artifact-signing-action@v1
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_SIGNING_CERTIFICATE_NAME }}
+          files: C:\helium-windows\build\src\out\Default\helium_update_helper.exe
+          description: Helium Update Helper
           description-url: https://github.com/imputnet/helium-windows
 
       - name: Build Helium installer and package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,10 @@ on:
         description: 'Create a release after build is done'
         default: false
 
+env:
+  WINSPARKLE_ED_KEY: ${{ vars.WINSPARKLE_ED_KEY }}
+  WINSPARKLE_AUTHENTICODE_ORG: ${{ vars.WINSPARKLE_AUTHENTICODE_ORG }}
+
 jobs:
   build-1:
     runs-on: ${{ github.event.inputs.runner }}

--- a/.github/workflows/main.yml.j2
+++ b/.github/workflows/main.yml.j2
@@ -17,6 +17,10 @@ on:
         description: 'Create a release after build is done'
         default: false
 
+env:
+  WINSPARKLE_ED_KEY: {% raw %}${{ vars.WINSPARKLE_ED_KEY }}{% endraw %}
+  WINSPARKLE_AUTHENTICODE_ORG: {% raw %}${{ vars.WINSPARKLE_AUTHENTICODE_ORG }}{% endraw %}
+
 jobs:
 {%- for arch in ["", "arm"] %}
 {%- set prefix = "build"    ~ ('-arm' if arch == 'arm' else '') %}

--- a/.github/workflows/main.yml.j2
+++ b/.github/workflows/main.yml.j2
@@ -97,6 +97,20 @@ jobs:
           description: Helium
           description-url: https://github.com/imputnet/helium-windows
 
+      # we want a different description here, so sign it separately again
+      - name: Sign Helium update helper
+        uses: azure/artifact-signing-action@v1
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_SIGNING_CERTIFICATE_NAME }}
+          files: C:\helium-windows\build\src\out\Default\helium_update_helper.exe
+          description: Helium Update Helper
+          description-url: https://github.com/imputnet/helium-windows
+
       - name: Build Helium installer and package
         id: stage2
         uses: ./.github/actions/stage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /.gcs_entries
 __pycache__
+/resources/generated

--- a/build.py
+++ b/build.py
@@ -356,7 +356,7 @@ def main():
         ninja_commandline.append('setup')
 
     if not args.ci or args.build_installer:
-        ninja_commandline.append('mini_installer_archive')
+        ninja_commandline.append('mini_installer')
 
     # Run ninja
     if args.ci:

--- a/build.py
+++ b/build.py
@@ -328,6 +328,13 @@ def main():
         else:
             gn_flags += 'is_official_build=true\n'
 
+        winsparkle_ed_key = os.environ.get('WINSPARKLE_ED_KEY', '')
+        authenticode_org = os.environ.get('WINSPARKLE_AUTHENTICODE_ORG', '')
+        if winsparkle_ed_key and authenticode_org:
+            gn_flags += 'enable_winsparkle=true\n'
+            gn_flags += f'winsparkle_ed_key="{winsparkle_ed_key}"\n'
+            gn_flags += f'winsparkle_authenticode_org="{authenticode_org}"\n'
+
         (source_tree / 'out/Default/args.gn').write_text(gn_flags, encoding=ENCODING)
 
     # Enter source tree to run build commands

--- a/downloads.ini
+++ b/downloads.ini
@@ -21,6 +21,15 @@ extractor = 7z
 output_path = third_party/nsis
 strip_leading_dirs = nsis-%(version)s
 
+[winsparkle]
+version = 0.9.3
+url = https://github.com/vslavik/winsparkle/archive/refs/tags/v%(version)s.zip
+download_filename = winsparkle-%(version)s.zip
+sha256 = 76cde0f62222a6fe516d494a847916b562f0daaf935485e38381cdbacb063f55
+extractor = 7z
+output_path = third_party/winsparkle
+strip_leading_dirs = winsparkle-%(version)s
+
 # Pre-built GNU bison from GnuWin32
 [bison-bin]
 version = 2.4.1

--- a/package.py
+++ b/package.py
@@ -88,6 +88,11 @@ def main():
     installer_output = _ROOT_DIR / 'build' / f'helium_{version}_{target_cpu}-installer.exe'
     _build_nsis_installer(version, target_cpu, build_outputs, installer_output)
 
+    mini_installer = build_outputs / 'mini_installer.exe'
+    shutil.copy2(
+        mini_installer,
+        _ROOT_DIR / 'build' / f'helium_{version}_{target_cpu}-mini-installer.exe')
+
     timestamp = None
     try:
         with open('build/src/build/util/LASTCHANGE.committime', 'r') as ct:

--- a/patches/helium/windows/change-branding.patch
+++ b/patches/helium/windows/change-branding.patch
@@ -1,125 +1,3 @@
---- a/chrome/app/chrome_version.rc.version
-+++ b/chrome/app/chrome_version.rc.version
-@@ -10,7 +10,7 @@
- //
- 
- VS_VERSION_INFO VERSIONINFO
-- FILEVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
-+ FILEVERSION @HELIUM_MAJOR@,@HELIUM_MINOR@,@HELIUM_PATCH@,@HELIUM_PLATFORM@
-  PRODUCTVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
-  FILEFLAGSMASK 0x17L
- #ifdef _DEBUG
-@@ -28,7 +28,7 @@ BEGIN
-         BEGIN
-             VALUE "CompanyName", "@COMPANY_FULLNAME@"
-             VALUE "FileDescription", "@PRODUCT_FULLNAME@"
--            VALUE "FileVersion", "@MAJOR@.@MINOR@.@BUILD@.@PATCH@"
-+            VALUE "FileVersion", "@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@"
-             VALUE "InternalName", "@INTERNAL_NAME@"
-             VALUE "LegalCopyright", "@COPYRIGHT@"
-             VALUE "OriginalFilename", "@ORIGINAL_FILENAME@"
---- a/chrome/app/main_dll_loader_win.cc
-+++ b/chrome/app/main_dll_loader_win.cc
-@@ -84,7 +84,7 @@ base::FilePath GetModulePath(std::wstrin
-   // executable's directory and return the path if it can be read. This is the
-   // expected location of modules for proper installs.
-   const base::FilePath module_path =
--      exe_dir.AppendASCII(chrome::kChromeVersion).Append(module_name);
-+      exe_dir.AppendASCII(chrome::kHeliumVersion).Append(module_name);
-   if (ModuleCanBeRead(module_path))
-     return module_path;
- 
---- a/chrome/app/version_assembly/BUILD.gn
-+++ b/chrome/app/version_assembly/BUILD.gn
-@@ -40,6 +40,6 @@ windows_manifest("chrome_exe_manifest")
- process_version("version_assembly_manifest") {
-   template_file = "version_assembly_manifest.template"
-   sources = [ "//chrome/VERSION" ]
--  output = "$root_build_dir/$chrome_version_full.manifest"
-+  output = "$root_build_dir/$helium_version_full.manifest"
-   process_only = true
- }
---- a/chrome/app/version_assembly/chrome_exe_manifest.template
-+++ b/chrome/app/version_assembly/chrome_exe_manifest.template
-@@ -3,8 +3,8 @@
-   <dependency>
-   <dependentAssembly>
-     <assemblyIdentity type='win32'
--      name='@MAJOR@.@MINOR@.@BUILD@.@PATCH@'
--      version='@MAJOR@.@MINOR@.@BUILD@.@PATCH@' language='*'/>
-+      name='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@'
-+      version='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@' language='*'/>
-   </dependentAssembly>
-   </dependency>
- </assembly>
-\ No newline at end of file
---- a/chrome/app/version_assembly/version_assembly_manifest.template
-+++ b/chrome/app/version_assembly/version_assembly_manifest.template
-@@ -1,8 +1,8 @@
- <assembly
-   xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
-   <assemblyIdentity
--      name='@MAJOR@.@MINOR@.@BUILD@.@PATCH@'
--      version='@MAJOR@.@MINOR@.@BUILD@.@PATCH@'
-+      name='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@'
-+      version='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@'
-       type='win32'/>
-   <file name='chrome_elf.dll'/>
- </assembly>
---- a/chrome/browser/chrome_content_browser_client.cc
-+++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -1301,7 +1301,7 @@ base::FilePath GetModulePath(std::wstrin
-   // executable's directory and return the path if it can be read. This is the
-   // expected location of modules for proper installs.
-   const base::FilePath module_path =
--      exe_dir.AppendASCII(chrome::kChromeVersion).Append(module_name);
-+      exe_dir.AppendASCII(chrome::kHeliumVersion).Append(module_name);
-   if (base::PathExists(module_path)) {
-     return module_path;
-   }
---- a/chrome/browser/web_applications/chrome_pwa_launcher/chrome_pwa_launcher_util.cc
-+++ b/chrome/browser/web_applications/chrome_pwa_launcher/chrome_pwa_launcher_util.cc
-@@ -21,7 +21,7 @@ base::FilePath GetChromePwaLauncherPath(
-   base::FilePath chrome_dir;
-   if (!base::PathService::Get(base::DIR_EXE, &chrome_dir))
-     return base::FilePath();
--  base::FilePath launcher_path = chrome_dir.AppendASCII(chrome::kChromeVersion)
-+  base::FilePath launcher_path = chrome_dir.AppendASCII(chrome::kHeliumVersion)
-                                      .Append(kChromePwaLauncherExecutable);
-   if (base::PathExists(launcher_path))
-     return launcher_path;
---- a/chrome/common/chrome_constants.cc
-+++ b/chrome/common/chrome_constants.cc
-@@ -12,6 +12,7 @@
- namespace chrome {
- 
- const char kChromeVersion[] = CHROME_VERSION_STRING;
-+const char kHeliumVersion[] = HELIUM_VERSION_STRING;
- 
- // The following should not be used for UI strings; they are meant
- // for system strings only. UI changes should be made in the GRD.
---- a/chrome/common/chrome_constants.h
-+++ b/chrome/common/chrome_constants.h
-@@ -15,6 +15,7 @@
- namespace chrome {
- 
- extern const char kChromeVersion[];
-+extern const char kHeliumVersion[];
- extern const base::FilePath::CharType kBrowserProcessExecutableName[];
- extern const base::FilePath::CharType kHelperProcessExecutableName[];
- extern const base::FilePath::CharType kBrowserProcessExecutablePath[];
---- a/chrome/common/chrome_version.h.in
-+++ b/chrome/common/chrome_version.h.in
-@@ -14,6 +14,9 @@
- #define CHROME_VERSION_BUILD @BUILD@
- #define CHROME_VERSION_PATCH @PATCH@
- 
-+#define HELIUM_VERSION_STRING \
-+  "@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@"
-+
- // Branding Information
- 
- #define COMPANY_FULLNAME_STRING "@COMPANY_FULLNAME@"
 --- a/chrome/install_static/chromium_install_modes.h
 +++ b/chrome/install_static/chromium_install_modes.h
 @@ -17,14 +17,14 @@ namespace install_static {
@@ -204,60 +82,6 @@
  // The prefix of the installer resource.
  const wchar_t kSetupPrefix[] = L"setup";
  
---- a/chrome/installer/mini_installer/mini_installer_exe_version.rc.version
-+++ b/chrome/installer/mini_installer/mini_installer_exe_version.rc.version
-@@ -8,7 +8,7 @@
- // SDK versions which causes headaches building in some environments. The
- // VERSIONINFO resource will always be at index 1.
- 1 VERSIONINFO
-- FILEVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
-+ FILEVERSION @HELIUM_MAJOR@,@HELIUM_MINOR@,@HELIUM_PATCH@,@HELIUM_PLATFORM@
-  PRODUCTVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
-  FILEFLAGSMASK 0x17L
- #ifdef _DEBUG
-@@ -26,7 +26,7 @@ BEGIN
-         BEGIN
-             VALUE "CompanyName", "@COMPANY_FULLNAME@"
-             VALUE "FileDescription", "@PRODUCT_INSTALLER_FULLNAME@"
--            VALUE "FileVersion", "@MAJOR@.@MINOR@.@BUILD@.@PATCH@"
-+            VALUE "FileVersion", "@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@"
-             VALUE "InternalName", "mini_installer"
-             VALUE "LegalCopyright", "@COPYRIGHT@"
-             VALUE "ProductName", "@PRODUCT_INSTALLER_FULLNAME@"
---- a/chrome/installer/setup/BUILD.gn
-+++ b/chrome/installer/setup/BUILD.gn
-@@ -114,6 +114,7 @@ if (is_win) {
-       "//components/crash/core/common",
-       "//components/metrics:client_info",
-       "//components/metrics:metrics_pref_names",
-+      "//base/version_info",
-       "//components/version_info:channel",
-       "//third_party/crashpad/crashpad/client",
-       "//third_party/crashpad/crashpad/util",
---- a/chrome/installer/setup/install_worker.cc
-+++ b/chrome/installer/setup/install_worker.cc
-@@ -34,6 +34,7 @@
- #include "base/strings/utf_string_conversions.h"
- #include "base/version.h"
- #include "base/version_info/channel.h"
-+#include "base/version_info/version_info.h"
- #include "base/win/registry.h"
- #include "base/win/security_util.h"
- #include "base/win/sid.h"
-@@ -583,10 +584,11 @@ void AddUninstallShortcutWorkItems(const
-                                          InstallUtil::GetPublisherName(), true);
-     install_list->AddSetRegValueWorkItem(
-         reg_root, uninstall_reg, KEY_WOW64_32KEY, L"Version",
--        ASCIIToWide(new_version.GetString()), true);
-+        ASCIIToWide(version_info::GetHeliumVersionNumber()), true);
-     install_list->AddSetRegValueWorkItem(
-         reg_root, uninstall_reg, KEY_WOW64_32KEY, L"DisplayVersion",
--        ASCIIToWide(new_version.GetString()), true);
-+        ASCIIToWide(version_info::GetHeliumVersionNumber()),
-+        true);
-     // TODO(wfh): Ensure that this value is preserved in the 64-bit hive when
-     // 64-bit installs place the uninstall information into the 64-bit registry.
-     install_list->AddSetRegValueWorkItem(reg_root, uninstall_reg,
 --- a/chrome/installer/setup/installer_crash_reporter_client.cc
 +++ b/chrome/installer/setup/installer_crash_reporter_client.cc
 @@ -103,7 +103,7 @@ bool InstallerCrashReporterClient::Repor
@@ -289,17 +113,6 @@
  
  const wchar_t kMediaPlayerRegPath[] =
      L"Software\\Microsoft\\MediaPlayer\\ShimInclusionList";
---- a/chrome/installer/setup/setup_main.cc
-+++ b/chrome/installer/setup/setup_main.cc
-@@ -478,7 +478,7 @@ installer::InstallStatus RenameChromeExe
-                                     WorkItem::MoveTreeOptions{});
- 
-   AddFinalizeUpdateWorkItems(original_state,
--                             base::Version(chrome::kChromeVersion),
-+                             base::Version(chrome::kHeliumVersion),
-                              *installer_state, setup_exe, install_list.get());
- 
-   // Add work items to delete Chrome's "opv", "cpv", and "cmd" values.
 --- a/chrome/installer/util/logging_installer.cc
 +++ b/chrome/installer/util/logging_installer.cc
 @@ -126,7 +126,7 @@ base::FilePath GetLogFilePath(const inst
@@ -322,39 +135,6 @@
  CHROME_PATCH_FILE_SUFFIX = "_patch"  # prefixed by options.output_name
  
  # compressed full archive suffix, will be prefixed by options.output_name
-@@ -47,24 +47,18 @@ def BuildVersion():
-     """Returns the full build version string constructed from information in
-     VERSION_FILE.  Any segment not found in that file will default to '0'.
-     """
--    major = 0
--    minor = 0
--    build = 0
--    patch = 0
-+    values = {}
-     # The version file is located at the directory ${CHROMIUM_SRC}/chrome.
-     version_file_path = os.path.join(os.path.dirname(__file__), '../../..',
-                                      VERSION_FILE)
-     for line in open(version_file_path, 'r'):
--        line = line.rstrip()
--        if line.startswith('MAJOR='):
--            major = line[6:]
--        elif line.startswith('MINOR='):
--            minor = line[6:]
--        elif line.startswith('BUILD='):
--            build = line[6:]
--        elif line.startswith('PATCH='):
--            patch = line[6:]
--    return '%s.%s.%s.%s' % (major, minor, build, patch)
-+        key, sep, value = line.rstrip().partition('=')
-+        if sep:
-+            values[key] = value
-+    return '%s.%s.%s.%s' % (values.get('HELIUM_MAJOR', '0'),
-+                            values.get('HELIUM_MINOR', '0'),
-+                            values.get('HELIUM_PATCH', '0'),
-+                            values.get('HELIUM_PLATFORM', '0'))
- 
- 
- def CompressUsingLZMA(build_dir,
 @@ -724,7 +718,7 @@ def _ParseOptions():
          '{BSDIFF|ZUCCHINI}.')
      parser.add_option('-n',
@@ -364,27 +144,6 @@
                        help='Name used to prefix names of generated archives.')
      parser.add_option('--enable_hidpi',
                        default='0',
---- a/chrome/version.gni
-+++ b/chrome/version.gni
-@@ -19,7 +19,9 @@
- # all values we need at once.
- _version_dictionary_template = "full = \"@MAJOR@.@MINOR@.@BUILD@.@PATCH@\" " +
-                                "major = \"@MAJOR@\" minor = \"@MINOR@\" " +
--                               "build = \"@BUILD@\" patch = \"@PATCH@\" "
-+                               "build = \"@BUILD@\" patch = \"@PATCH@\" " +
-+                               "helium_full = \"@HELIUM_MAJOR@.@HELIUM_MINOR@" +
-+                               ".@HELIUM_PATCH@.@HELIUM_PLATFORM@\" "
- 
- # The file containing the Chrome version number.
- chrome_version_file = "//chrome/VERSION"
-@@ -160,6 +162,7 @@ _result = exec_script("//build/util/vers
- 
- # Full version. For example "45.0.12321.0"
- chrome_version_full = _result.full
-+helium_version_full = _result.helium_full
- 
- # The constituent parts of the full version.
- chrome_version_major = _result.major
 --- a/components/policy/tools/generate_policy_source.py
 +++ b/components/policy/tools/generate_policy_source.py
 @@ -28,7 +28,7 @@ from xml.sax.saxutils import escape as x
@@ -425,21 +184,3 @@
                  },
                  'namespace': 'Chromium.Policies.Chromium',
              },
---- a/chrome/installer/setup/last_breaking_installer_version.cc
-+++ b/chrome/installer/setup/last_breaking_installer_version.cc
-@@ -11,12 +11,8 @@ namespace installer {
- // When updating the documentation, keep a history of maximum 3 milestones prior
- // the current version because downgrades are supported for 3 milestones.
- //
--// Breaking changes from 85.0.4169.0:
--//  Change: Default installation directory for fresh 64 bits browsers moved from
--//    base::DIR_PROGRAM_FILESX86 to DIR_PROGRAM_FILES.
--//  Reason for being breaking: Downgrading to previous version will result in
--//    stale data in DIR_PROGRAM_FILES since the previous installers do not know
--//    if there is Chrome data at this location.
--const wchar_t kLastBreakingInstallerVersion[] = L"85.0.4169.0";
-+// Helium uses its own version scheme, which is below every Chromium
-+// "breaking installer version".
-+const wchar_t kLastBreakingInstallerVersion[] = L"0.0.0.0";
- 
- }  // namespace installer

--- a/patches/helium/windows/change-branding.patch
+++ b/patches/helium/windows/change-branding.patch
@@ -193,6 +193,17 @@
          .tracing_service_clsid = {0x83f69367,
                                    0x442d,
                                    0x447f,
+--- a/chrome/installer/mini_installer/mini_installer_constants.cc
++++ b/chrome/installer/mini_installer/mini_installer_constants.cc
+@@ -12,7 +12,7 @@ namespace mini_installer {
+ // The target name of the installer extracted from resources.
+ const wchar_t kSetupExe[] = L"setup.exe";
+ // The prefix of the chrome archive resource.
+-const wchar_t kChromeArchivePrefix[] = L"chrome";
++const wchar_t kChromeArchivePrefix[] = L"helium";
+ // The prefix of the installer resource.
+ const wchar_t kSetupPrefix[] = L"setup";
+ 
 --- a/chrome/installer/mini_installer/mini_installer_exe_version.rc.version
 +++ b/chrome/installer/mini_installer/mini_installer_exe_version.rc.version
 @@ -8,7 +8,7 @@

--- a/patches/helium/windows/change-branding.patch
+++ b/patches/helium/windows/change-branding.patch
@@ -1,3 +1,125 @@
+--- a/chrome/app/chrome_version.rc.version
++++ b/chrome/app/chrome_version.rc.version
+@@ -10,7 +10,7 @@
+ //
+ 
+ VS_VERSION_INFO VERSIONINFO
+- FILEVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
++ FILEVERSION @HELIUM_MAJOR@,@HELIUM_MINOR@,@HELIUM_PATCH@,@HELIUM_PLATFORM@
+  PRODUCTVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
+  FILEFLAGSMASK 0x17L
+ #ifdef _DEBUG
+@@ -28,7 +28,7 @@ BEGIN
+         BEGIN
+             VALUE "CompanyName", "@COMPANY_FULLNAME@"
+             VALUE "FileDescription", "@PRODUCT_FULLNAME@"
+-            VALUE "FileVersion", "@MAJOR@.@MINOR@.@BUILD@.@PATCH@"
++            VALUE "FileVersion", "@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@"
+             VALUE "InternalName", "@INTERNAL_NAME@"
+             VALUE "LegalCopyright", "@COPYRIGHT@"
+             VALUE "OriginalFilename", "@ORIGINAL_FILENAME@"
+--- a/chrome/app/main_dll_loader_win.cc
++++ b/chrome/app/main_dll_loader_win.cc
+@@ -84,7 +84,7 @@ base::FilePath GetModulePath(std::wstrin
+   // executable's directory and return the path if it can be read. This is the
+   // expected location of modules for proper installs.
+   const base::FilePath module_path =
+-      exe_dir.AppendASCII(chrome::kChromeVersion).Append(module_name);
++      exe_dir.AppendASCII(chrome::kHeliumVersion).Append(module_name);
+   if (ModuleCanBeRead(module_path))
+     return module_path;
+ 
+--- a/chrome/app/version_assembly/BUILD.gn
++++ b/chrome/app/version_assembly/BUILD.gn
+@@ -40,6 +40,6 @@ windows_manifest("chrome_exe_manifest")
+ process_version("version_assembly_manifest") {
+   template_file = "version_assembly_manifest.template"
+   sources = [ "//chrome/VERSION" ]
+-  output = "$root_build_dir/$chrome_version_full.manifest"
++  output = "$root_build_dir/$helium_version_full.manifest"
+   process_only = true
+ }
+--- a/chrome/app/version_assembly/chrome_exe_manifest.template
++++ b/chrome/app/version_assembly/chrome_exe_manifest.template
+@@ -3,8 +3,8 @@
+   <dependency>
+   <dependentAssembly>
+     <assemblyIdentity type='win32'
+-      name='@MAJOR@.@MINOR@.@BUILD@.@PATCH@'
+-      version='@MAJOR@.@MINOR@.@BUILD@.@PATCH@' language='*'/>
++      name='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@'
++      version='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@' language='*'/>
+   </dependentAssembly>
+   </dependency>
+ </assembly>
+\ No newline at end of file
+--- a/chrome/app/version_assembly/version_assembly_manifest.template
++++ b/chrome/app/version_assembly/version_assembly_manifest.template
+@@ -1,8 +1,8 @@
+ <assembly
+   xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+   <assemblyIdentity
+-      name='@MAJOR@.@MINOR@.@BUILD@.@PATCH@'
+-      version='@MAJOR@.@MINOR@.@BUILD@.@PATCH@'
++      name='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@'
++      version='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@'
+       type='win32'/>
+   <file name='chrome_elf.dll'/>
+ </assembly>
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -1301,7 +1301,7 @@ base::FilePath GetModulePath(std::wstrin
+   // executable's directory and return the path if it can be read. This is the
+   // expected location of modules for proper installs.
+   const base::FilePath module_path =
+-      exe_dir.AppendASCII(chrome::kChromeVersion).Append(module_name);
++      exe_dir.AppendASCII(chrome::kHeliumVersion).Append(module_name);
+   if (base::PathExists(module_path)) {
+     return module_path;
+   }
+--- a/chrome/browser/web_applications/chrome_pwa_launcher/chrome_pwa_launcher_util.cc
++++ b/chrome/browser/web_applications/chrome_pwa_launcher/chrome_pwa_launcher_util.cc
+@@ -21,7 +21,7 @@ base::FilePath GetChromePwaLauncherPath(
+   base::FilePath chrome_dir;
+   if (!base::PathService::Get(base::DIR_EXE, &chrome_dir))
+     return base::FilePath();
+-  base::FilePath launcher_path = chrome_dir.AppendASCII(chrome::kChromeVersion)
++  base::FilePath launcher_path = chrome_dir.AppendASCII(chrome::kHeliumVersion)
+                                      .Append(kChromePwaLauncherExecutable);
+   if (base::PathExists(launcher_path))
+     return launcher_path;
+--- a/chrome/common/chrome_constants.cc
++++ b/chrome/common/chrome_constants.cc
+@@ -12,6 +12,7 @@
+ namespace chrome {
+ 
+ const char kChromeVersion[] = CHROME_VERSION_STRING;
++const char kHeliumVersion[] = HELIUM_VERSION_STRING;
+ 
+ // The following should not be used for UI strings; they are meant
+ // for system strings only. UI changes should be made in the GRD.
+--- a/chrome/common/chrome_constants.h
++++ b/chrome/common/chrome_constants.h
+@@ -15,6 +15,7 @@
+ namespace chrome {
+ 
+ extern const char kChromeVersion[];
++extern const char kHeliumVersion[];
+ extern const base::FilePath::CharType kBrowserProcessExecutableName[];
+ extern const base::FilePath::CharType kHelperProcessExecutableName[];
+ extern const base::FilePath::CharType kBrowserProcessExecutablePath[];
+--- a/chrome/common/chrome_version.h.in
++++ b/chrome/common/chrome_version.h.in
+@@ -14,6 +14,9 @@
+ #define CHROME_VERSION_BUILD @BUILD@
+ #define CHROME_VERSION_PATCH @PATCH@
+ 
++#define HELIUM_VERSION_STRING \
++  "@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@"
++
+ // Branding Information
+ 
+ #define COMPANY_FULLNAME_STRING "@COMPANY_FULLNAME@"
 --- a/chrome/install_static/chromium_install_modes.h
 +++ b/chrome/install_static/chromium_install_modes.h
 @@ -17,14 +17,14 @@ namespace install_static {
@@ -71,108 +193,26 @@
          .tracing_service_clsid = {0x83f69367,
                                    0x442d,
                                    0x447f,
---- a/chrome/installer/setup/installer_crash_reporter_client.cc
-+++ b/chrome/installer/setup/installer_crash_reporter_client.cc
-@@ -103,7 +103,7 @@ bool InstallerCrashReporterClient::Repor
-       L"SOFTWARE\\Policies\\Google\\Chrome";
- #else
-   static const wchar_t kRegistryChromePolicyKey[] =
--      L"SOFTWARE\\Policies\\Chromium";
-+      L"SOFTWARE\\Policies\\Helium";
- #endif
-   static const wchar_t kMetricsReportingEnabled[] = L"MetricsReportingEnabled";
- 
---- a/components/policy/tools/generate_policy_source.py
-+++ b/components/policy/tools/generate_policy_source.py
-@@ -28,7 +28,7 @@ from xml.sax.saxutils import escape as x
- 
- CHROME_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Google\\\\Chrome'
- CHROME_FOR_TESTING_POLICY_KEY = CHROME_POLICY_KEY + ' for Testing'
--CHROMIUM_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Chromium'
-+CHROMIUM_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Helium'
- PLATFORM_STRINGS = {
-     'chrome_frame': ['win'],
-     'chrome_os': ['chrome_os'],
---- a/chrome/installer/setup/setup_constants.cc
-+++ b/chrome/installer/setup/setup_constants.cc
-@@ -7,14 +7,14 @@
- namespace installer {
- 
- // Elements that make up install paths.
--const wchar_t kChromeArchive[] = L"chrome.7z";
--const wchar_t kChromeCompressedArchive[] = L"chrome.packed.7z";
-+const wchar_t kChromeArchive[] = L"helium.7z";
-+const wchar_t kChromeCompressedArchive[] = L"helium.packed.7z";
- const char kVisualElements[] = "VisualElements";
- const wchar_t kVisualElementsManifest[] = L"chrome.VisualElementsManifest.xml";
- 
- // Sub directory of install source package under install temporary directory.
- const wchar_t kInstallSourceDir[] = L"source";
--const wchar_t kInstallSourceChromeDir[] = L"Chrome-bin";
-+const wchar_t kInstallSourceChromeDir[] = L"Helium-bin";
- 
- const wchar_t kMediaPlayerRegPath[] =
-     L"Software\\Microsoft\\MediaPlayer\\ShimInclusionList";
---- a/chrome/installer/util/logging_installer.cc
-+++ b/chrome/installer/util/logging_installer.cc
-@@ -126,7 +126,7 @@ base::FilePath GetLogFilePath(const inst
- #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
-       FILE_PATH_LITERAL("chrome_installer.log");
- #else  // BUILDFLAG(CHROMIUM_BRANDING)
--      FILE_PATH_LITERAL("chromium_installer.log");
-+      FILE_PATH_LITERAL("helium_installer.log");
- #endif
- 
-   // Fallback to current directory if getting the secure or temp directory
---- a/chrome/tools/build/win/create_installer_archive.py
-+++ b/chrome/tools/build/win/create_installer_archive.py
-@@ -25,7 +25,7 @@ ARCHIVE_DIR = "installer_archive"
- # suffix to uncompressed full archive file, appended to options.output_name
- ARCHIVE_SUFFIX = ".7z"
- BSDIFF_EXEC = "bsdiff.exe"
--CHROME_DIR = "Chrome-bin"
-+CHROME_DIR = "Helium-bin"
- CHROME_PATCH_FILE_SUFFIX = "_patch"  # prefixed by options.output_name
- 
- # compressed full archive suffix, will be prefixed by options.output_name
-@@ -724,7 +724,7 @@ def _ParseOptions():
-         '{BSDIFF|ZUCCHINI}.')
-     parser.add_option('-n',
-                       '--output_name',
--                      default='chrome',
-+                      default='helium',
-                       help='Name used to prefix names of generated archives.')
-     parser.add_option('--enable_hidpi',
-                       default='0',
---- a/components/policy/tools/template_writers/writer_configuration.py
-+++ b/components/policy/tools/template_writers/writer_configuration.py
-@@ -27,21 +27,21 @@ def GetConfigurationForBuild(defines):
-   if '_chromium' in defines:
-     config = {
-         'build': 'chromium',
--        'app_name': 'Chromium',
-+        'app_name': 'Helium',
-         'doc_url': 'https://chromeenterprise.google/policies/',
-         'frame_name': 'Chromium Frame',
-         'os_name': 'ChromiumOS',
-         'webview_name': 'Chromium WebView',
-         'win_config': {
-             'win': {
--                'reg_mandatory_key_name': 'Software\\Policies\\Chromium',
-+                'reg_mandatory_key_name': 'Software\\Policies\\Helium',
-                 'reg_recommended_key_name':
--                'Software\\Policies\\Chromium\\Recommended',
-+                'Software\\Policies\\Helium\\Recommended',
-                 'mandatory_category_path': ['chromium'],
-                 'recommended_category_path': ['chromium_recommended'],
-                 'category_path_strings': {
--                    'chromium': 'Chromium',
--                    'chromium_recommended': 'Chromium - {doc_recommended}',
-+                    'chromium': 'Helium',
-+                    'chromium_recommended': 'Helium - {doc_recommended}',
-                 },
-                 'namespace': 'Chromium.Policies.Chromium',
-             },
+--- a/chrome/installer/mini_installer/mini_installer_exe_version.rc.version
++++ b/chrome/installer/mini_installer/mini_installer_exe_version.rc.version
+@@ -8,7 +8,7 @@
+ // SDK versions which causes headaches building in some environments. The
+ // VERSIONINFO resource will always be at index 1.
+ 1 VERSIONINFO
+- FILEVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
++ FILEVERSION @HELIUM_MAJOR@,@HELIUM_MINOR@,@HELIUM_PATCH@,@HELIUM_PLATFORM@
+  PRODUCTVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
+  FILEFLAGSMASK 0x17L
+ #ifdef _DEBUG
+@@ -26,7 +26,7 @@ BEGIN
+         BEGIN
+             VALUE "CompanyName", "@COMPANY_FULLNAME@"
+             VALUE "FileDescription", "@PRODUCT_INSTALLER_FULLNAME@"
+-            VALUE "FileVersion", "@MAJOR@.@MINOR@.@BUILD@.@PATCH@"
++            VALUE "FileVersion", "@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@"
+             VALUE "InternalName", "mini_installer"
+             VALUE "LegalCopyright", "@COPYRIGHT@"
+             VALUE "ProductName", "@PRODUCT_INSTALLER_FULLNAME@"
 --- a/chrome/installer/setup/BUILD.gn
 +++ b/chrome/installer/setup/BUILD.gn
 @@ -114,6 +114,7 @@ if (is_win) {
@@ -207,3 +247,170 @@
      // TODO(wfh): Ensure that this value is preserved in the 64-bit hive when
      // 64-bit installs place the uninstall information into the 64-bit registry.
      install_list->AddSetRegValueWorkItem(reg_root, uninstall_reg,
+--- a/chrome/installer/setup/installer_crash_reporter_client.cc
++++ b/chrome/installer/setup/installer_crash_reporter_client.cc
+@@ -103,7 +103,7 @@ bool InstallerCrashReporterClient::Repor
+       L"SOFTWARE\\Policies\\Google\\Chrome";
+ #else
+   static const wchar_t kRegistryChromePolicyKey[] =
+-      L"SOFTWARE\\Policies\\Chromium";
++      L"SOFTWARE\\Policies\\Helium";
+ #endif
+   static const wchar_t kMetricsReportingEnabled[] = L"MetricsReportingEnabled";
+ 
+--- a/chrome/installer/setup/setup_constants.cc
++++ b/chrome/installer/setup/setup_constants.cc
+@@ -7,14 +7,14 @@
+ namespace installer {
+ 
+ // Elements that make up install paths.
+-const wchar_t kChromeArchive[] = L"chrome.7z";
+-const wchar_t kChromeCompressedArchive[] = L"chrome.packed.7z";
++const wchar_t kChromeArchive[] = L"helium.7z";
++const wchar_t kChromeCompressedArchive[] = L"helium.packed.7z";
+ const char kVisualElements[] = "VisualElements";
+ const wchar_t kVisualElementsManifest[] = L"chrome.VisualElementsManifest.xml";
+ 
+ // Sub directory of install source package under install temporary directory.
+ const wchar_t kInstallSourceDir[] = L"source";
+-const wchar_t kInstallSourceChromeDir[] = L"Chrome-bin";
++const wchar_t kInstallSourceChromeDir[] = L"Helium-bin";
+ 
+ const wchar_t kMediaPlayerRegPath[] =
+     L"Software\\Microsoft\\MediaPlayer\\ShimInclusionList";
+--- a/chrome/installer/setup/setup_main.cc
++++ b/chrome/installer/setup/setup_main.cc
+@@ -478,7 +478,7 @@ installer::InstallStatus RenameChromeExe
+                                     WorkItem::MoveTreeOptions{});
+ 
+   AddFinalizeUpdateWorkItems(original_state,
+-                             base::Version(chrome::kChromeVersion),
++                             base::Version(chrome::kHeliumVersion),
+                              *installer_state, setup_exe, install_list.get());
+ 
+   // Add work items to delete Chrome's "opv", "cpv", and "cmd" values.
+--- a/chrome/installer/util/logging_installer.cc
++++ b/chrome/installer/util/logging_installer.cc
+@@ -126,7 +126,7 @@ base::FilePath GetLogFilePath(const inst
+ #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
+       FILE_PATH_LITERAL("chrome_installer.log");
+ #else  // BUILDFLAG(CHROMIUM_BRANDING)
+-      FILE_PATH_LITERAL("chromium_installer.log");
++      FILE_PATH_LITERAL("helium_installer.log");
+ #endif
+ 
+   // Fallback to current directory if getting the secure or temp directory
+--- a/chrome/tools/build/win/create_installer_archive.py
++++ b/chrome/tools/build/win/create_installer_archive.py
+@@ -25,7 +25,7 @@ ARCHIVE_DIR = "installer_archive"
+ # suffix to uncompressed full archive file, appended to options.output_name
+ ARCHIVE_SUFFIX = ".7z"
+ BSDIFF_EXEC = "bsdiff.exe"
+-CHROME_DIR = "Chrome-bin"
++CHROME_DIR = "Helium-bin"
+ CHROME_PATCH_FILE_SUFFIX = "_patch"  # prefixed by options.output_name
+ 
+ # compressed full archive suffix, will be prefixed by options.output_name
+@@ -47,24 +47,18 @@ def BuildVersion():
+     """Returns the full build version string constructed from information in
+     VERSION_FILE.  Any segment not found in that file will default to '0'.
+     """
+-    major = 0
+-    minor = 0
+-    build = 0
+-    patch = 0
++    values = {}
+     # The version file is located at the directory ${CHROMIUM_SRC}/chrome.
+     version_file_path = os.path.join(os.path.dirname(__file__), '../../..',
+                                      VERSION_FILE)
+     for line in open(version_file_path, 'r'):
+-        line = line.rstrip()
+-        if line.startswith('MAJOR='):
+-            major = line[6:]
+-        elif line.startswith('MINOR='):
+-            minor = line[6:]
+-        elif line.startswith('BUILD='):
+-            build = line[6:]
+-        elif line.startswith('PATCH='):
+-            patch = line[6:]
+-    return '%s.%s.%s.%s' % (major, minor, build, patch)
++        key, sep, value = line.rstrip().partition('=')
++        if sep:
++            values[key] = value
++    return '%s.%s.%s.%s' % (values.get('HELIUM_MAJOR', '0'),
++                            values.get('HELIUM_MINOR', '0'),
++                            values.get('HELIUM_PATCH', '0'),
++                            values.get('HELIUM_PLATFORM', '0'))
+ 
+ 
+ def CompressUsingLZMA(build_dir,
+@@ -724,7 +718,7 @@ def _ParseOptions():
+         '{BSDIFF|ZUCCHINI}.')
+     parser.add_option('-n',
+                       '--output_name',
+-                      default='chrome',
++                      default='helium',
+                       help='Name used to prefix names of generated archives.')
+     parser.add_option('--enable_hidpi',
+                       default='0',
+--- a/chrome/version.gni
++++ b/chrome/version.gni
+@@ -19,7 +19,9 @@
+ # all values we need at once.
+ _version_dictionary_template = "full = \"@MAJOR@.@MINOR@.@BUILD@.@PATCH@\" " +
+                                "major = \"@MAJOR@\" minor = \"@MINOR@\" " +
+-                               "build = \"@BUILD@\" patch = \"@PATCH@\" "
++                               "build = \"@BUILD@\" patch = \"@PATCH@\" " +
++                               "helium_full = \"@HELIUM_MAJOR@.@HELIUM_MINOR@" +
++                               ".@HELIUM_PATCH@.@HELIUM_PLATFORM@\" "
+ 
+ # The file containing the Chrome version number.
+ chrome_version_file = "//chrome/VERSION"
+@@ -160,6 +162,7 @@ _result = exec_script("//build/util/vers
+ 
+ # Full version. For example "45.0.12321.0"
+ chrome_version_full = _result.full
++helium_version_full = _result.helium_full
+ 
+ # The constituent parts of the full version.
+ chrome_version_major = _result.major
+--- a/components/policy/tools/generate_policy_source.py
++++ b/components/policy/tools/generate_policy_source.py
+@@ -28,7 +28,7 @@ from xml.sax.saxutils import escape as x
+ 
+ CHROME_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Google\\\\Chrome'
+ CHROME_FOR_TESTING_POLICY_KEY = CHROME_POLICY_KEY + ' for Testing'
+-CHROMIUM_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Chromium'
++CHROMIUM_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Helium'
+ PLATFORM_STRINGS = {
+     'chrome_frame': ['win'],
+     'chrome_os': ['chrome_os'],
+--- a/components/policy/tools/template_writers/writer_configuration.py
++++ b/components/policy/tools/template_writers/writer_configuration.py
+@@ -27,21 +27,21 @@ def GetConfigurationForBuild(defines):
+   if '_chromium' in defines:
+     config = {
+         'build': 'chromium',
+-        'app_name': 'Chromium',
++        'app_name': 'Helium',
+         'doc_url': 'https://chromeenterprise.google/policies/',
+         'frame_name': 'Chromium Frame',
+         'os_name': 'ChromiumOS',
+         'webview_name': 'Chromium WebView',
+         'win_config': {
+             'win': {
+-                'reg_mandatory_key_name': 'Software\\Policies\\Chromium',
++                'reg_mandatory_key_name': 'Software\\Policies\\Helium',
+                 'reg_recommended_key_name':
+-                'Software\\Policies\\Chromium\\Recommended',
++                'Software\\Policies\\Helium\\Recommended',
+                 'mandatory_category_path': ['chromium'],
+                 'recommended_category_path': ['chromium_recommended'],
+                 'category_path_strings': {
+-                    'chromium': 'Chromium',
+-                    'chromium_recommended': 'Chromium - {doc_recommended}',
++                    'chromium': 'Helium',
++                    'chromium_recommended': 'Helium - {doc_recommended}',
+                 },
+                 'namespace': 'Chromium.Policies.Chromium',
+             },

--- a/patches/helium/windows/change-branding.patch
+++ b/patches/helium/windows/change-branding.patch
@@ -93,6 +93,17 @@
  #endif
    static const wchar_t kMetricsReportingEnabled[] = L"MetricsReportingEnabled";
  
+--- a/components/policy/tools/generate_policy_source.py
++++ b/components/policy/tools/generate_policy_source.py
+@@ -28,7 +28,7 @@ from xml.sax.saxutils import escape as x
+ 
+ CHROME_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Google\\\\Chrome'
+ CHROME_FOR_TESTING_POLICY_KEY = CHROME_POLICY_KEY + ' for Testing'
+-CHROMIUM_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Chromium'
++CHROMIUM_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Helium'
+ PLATFORM_STRINGS = {
+     'chrome_frame': ['win'],
+     'chrome_os': ['chrome_os'],
 --- a/chrome/installer/setup/setup_constants.cc
 +++ b/chrome/installer/setup/setup_constants.cc
 @@ -7,14 +7,14 @@
@@ -135,7 +146,7 @@
  CHROME_PATCH_FILE_SUFFIX = "_patch"  # prefixed by options.output_name
  
  # compressed full archive suffix, will be prefixed by options.output_name
-@@ -724,7 +718,7 @@ def _ParseOptions():
+@@ -724,7 +724,7 @@ def _ParseOptions():
          '{BSDIFF|ZUCCHINI}.')
      parser.add_option('-n',
                        '--output_name',
@@ -144,17 +155,6 @@
                        help='Name used to prefix names of generated archives.')
      parser.add_option('--enable_hidpi',
                        default='0',
---- a/components/policy/tools/generate_policy_source.py
-+++ b/components/policy/tools/generate_policy_source.py
-@@ -28,7 +28,7 @@ from xml.sax.saxutils import escape as x
- 
- CHROME_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Google\\\\Chrome'
- CHROME_FOR_TESTING_POLICY_KEY = CHROME_POLICY_KEY + ' for Testing'
--CHROMIUM_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Chromium'
-+CHROMIUM_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\Helium'
- PLATFORM_STRINGS = {
-     'chrome_frame': ['win'],
-     'chrome_os': ['chrome_os'],
 --- a/components/policy/tools/template_writers/writer_configuration.py
 +++ b/components/policy/tools/template_writers/writer_configuration.py
 @@ -27,21 +27,21 @@ def GetConfigurationForBuild(defines):

--- a/patches/helium/windows/change-branding.patch
+++ b/patches/helium/windows/change-branding.patch
@@ -425,3 +425,21 @@
                  },
                  'namespace': 'Chromium.Policies.Chromium',
              },
+--- a/chrome/installer/setup/last_breaking_installer_version.cc
++++ b/chrome/installer/setup/last_breaking_installer_version.cc
+@@ -11,12 +11,8 @@ namespace installer {
+ // When updating the documentation, keep a history of maximum 3 milestones prior
+ // the current version because downgrades are supported for 3 milestones.
+ //
+-// Breaking changes from 85.0.4169.0:
+-//  Change: Default installation directory for fresh 64 bits browsers moved from
+-//    base::DIR_PROGRAM_FILESX86 to DIR_PROGRAM_FILES.
+-//  Reason for being breaking: Downgrading to previous version will result in
+-//    stale data in DIR_PROGRAM_FILES since the previous installers do not know
+-//    if there is Chrome data at this location.
+-const wchar_t kLastBreakingInstallerVersion[] = L"85.0.4169.0";
++// Helium uses its own version scheme, which is below every Chromium
++// "breaking installer version".
++const wchar_t kLastBreakingInstallerVersion[] = L"0.0.0.0";
+ 
+ }  // namespace installer

--- a/patches/helium/windows/helium-versioning.patch
+++ b/patches/helium/windows/helium-versioning.patch
@@ -68,7 +68,7 @@
  </assembly>
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -1301,7 +1301,7 @@ base::FilePath GetModulePath(std::wstrin
+@@ -1292,7 +1292,7 @@ base::FilePath GetModulePath(std::wstrin
    // executable's directory and return the path if it can be read. This is the
    // expected location of modules for proper installs.
    const base::FilePath module_path =
@@ -160,7 +160,7 @@
  #include "base/win/registry.h"
  #include "base/win/security_util.h"
  #include "base/win/sid.h"
-@@ -579,10 +580,11 @@ void AddUninstallShortcutWorkItems(const
+@@ -583,10 +584,11 @@ void AddUninstallShortcutWorkItems(const
                                           InstallUtil::GetPublisherName(), true);
      install_list->AddSetRegValueWorkItem(
          reg_root, uninstall_reg, KEY_WOW64_32KEY, L"Version",
@@ -176,7 +176,7 @@
      install_list->AddSetRegValueWorkItem(reg_root, uninstall_reg,
 --- a/chrome/installer/setup/setup_main.cc
 +++ b/chrome/installer/setup/setup_main.cc
-@@ -478,7 +478,7 @@ installer::InstallStatus RenameChromeExe
+@@ -543,7 +543,7 @@ installer::InstallStatus RenameChromeExe
                                      WorkItem::MoveTreeOptions{});
  
    AddFinalizeUpdateWorkItems(original_state,

--- a/patches/helium/windows/helium-versioning.patch
+++ b/patches/helium/windows/helium-versioning.patch
@@ -1,0 +1,261 @@
+--- a/chrome/app/chrome_version.rc.version
++++ b/chrome/app/chrome_version.rc.version
+@@ -10,7 +10,7 @@
+ //
+ 
+ VS_VERSION_INFO VERSIONINFO
+- FILEVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
++ FILEVERSION @HELIUM_MAJOR@,@HELIUM_MINOR@,@HELIUM_PATCH@,@HELIUM_PLATFORM@
+  PRODUCTVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
+  FILEFLAGSMASK 0x17L
+ #ifdef _DEBUG
+@@ -28,7 +28,7 @@ BEGIN
+         BEGIN
+             VALUE "CompanyName", "@COMPANY_FULLNAME@"
+             VALUE "FileDescription", "@PRODUCT_FULLNAME@"
+-            VALUE "FileVersion", "@MAJOR@.@MINOR@.@BUILD@.@PATCH@"
++            VALUE "FileVersion", "@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@"
+             VALUE "InternalName", "@INTERNAL_NAME@"
+             VALUE "LegalCopyright", "@COPYRIGHT@"
+             VALUE "OriginalFilename", "@ORIGINAL_FILENAME@"
+--- a/chrome/app/main_dll_loader_win.cc
++++ b/chrome/app/main_dll_loader_win.cc
+@@ -84,7 +84,7 @@ base::FilePath GetModulePath(std::wstrin
+   // executable's directory and return the path if it can be read. This is the
+   // expected location of modules for proper installs.
+   const base::FilePath module_path =
+-      exe_dir.AppendASCII(chrome::kChromeVersion).Append(module_name);
++      exe_dir.AppendASCII(chrome::kHeliumVersion).Append(module_name);
+   if (ModuleCanBeRead(module_path))
+     return module_path;
+ 
+--- a/chrome/app/version_assembly/BUILD.gn
++++ b/chrome/app/version_assembly/BUILD.gn
+@@ -40,6 +40,6 @@ windows_manifest("chrome_exe_manifest")
+ process_version("version_assembly_manifest") {
+   template_file = "version_assembly_manifest.template"
+   sources = [ "//chrome/VERSION" ]
+-  output = "$root_build_dir/$chrome_version_full.manifest"
++  output = "$root_build_dir/$helium_version_full.manifest"
+   process_only = true
+ }
+--- a/chrome/app/version_assembly/chrome_exe_manifest.template
++++ b/chrome/app/version_assembly/chrome_exe_manifest.template
+@@ -3,8 +3,8 @@
+   <dependency>
+   <dependentAssembly>
+     <assemblyIdentity type='win32'
+-      name='@MAJOR@.@MINOR@.@BUILD@.@PATCH@'
+-      version='@MAJOR@.@MINOR@.@BUILD@.@PATCH@' language='*'/>
++      name='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@'
++      version='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@' language='*'/>
+   </dependentAssembly>
+   </dependency>
+ </assembly>
+\ No newline at end of file
+--- a/chrome/app/version_assembly/version_assembly_manifest.template
++++ b/chrome/app/version_assembly/version_assembly_manifest.template
+@@ -1,8 +1,8 @@
+ <assembly
+   xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+   <assemblyIdentity
+-      name='@MAJOR@.@MINOR@.@BUILD@.@PATCH@'
+-      version='@MAJOR@.@MINOR@.@BUILD@.@PATCH@'
++      name='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@'
++      version='@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@'
+       type='win32'/>
+   <file name='chrome_elf.dll'/>
+ </assembly>
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -1301,7 +1301,7 @@ base::FilePath GetModulePath(std::wstrin
+   // executable's directory and return the path if it can be read. This is the
+   // expected location of modules for proper installs.
+   const base::FilePath module_path =
+-      exe_dir.AppendASCII(chrome::kChromeVersion).Append(module_name);
++      exe_dir.AppendASCII(chrome::kHeliumVersion).Append(module_name);
+   if (base::PathExists(module_path)) {
+     return module_path;
+   }
+--- a/chrome/browser/web_applications/chrome_pwa_launcher/chrome_pwa_launcher_util.cc
++++ b/chrome/browser/web_applications/chrome_pwa_launcher/chrome_pwa_launcher_util.cc
+@@ -21,7 +21,7 @@ base::FilePath GetChromePwaLauncherPath(
+   base::FilePath chrome_dir;
+   if (!base::PathService::Get(base::DIR_EXE, &chrome_dir))
+     return base::FilePath();
+-  base::FilePath launcher_path = chrome_dir.AppendASCII(chrome::kChromeVersion)
++  base::FilePath launcher_path = chrome_dir.AppendASCII(chrome::kHeliumVersion)
+                                      .Append(kChromePwaLauncherExecutable);
+   if (base::PathExists(launcher_path))
+     return launcher_path;
+--- a/chrome/common/chrome_constants.cc
++++ b/chrome/common/chrome_constants.cc
+@@ -12,6 +12,7 @@
+ namespace chrome {
+ 
+ const char kChromeVersion[] = CHROME_VERSION_STRING;
++const char kHeliumVersion[] = HELIUM_VERSION_STRING;
+ 
+ // The following should not be used for UI strings; they are meant
+ // for system strings only. UI changes should be made in the GRD.
+--- a/chrome/common/chrome_constants.h
++++ b/chrome/common/chrome_constants.h
+@@ -15,6 +15,7 @@
+ namespace chrome {
+ 
+ extern const char kChromeVersion[];
++extern const char kHeliumVersion[];
+ extern const base::FilePath::CharType kBrowserProcessExecutableName[];
+ extern const base::FilePath::CharType kHelperProcessExecutableName[];
+ extern const base::FilePath::CharType kBrowserProcessExecutablePath[];
+--- a/chrome/common/chrome_version.h.in
++++ b/chrome/common/chrome_version.h.in
+@@ -14,6 +14,9 @@
+ #define CHROME_VERSION_BUILD @BUILD@
+ #define CHROME_VERSION_PATCH @PATCH@
+ 
++#define HELIUM_VERSION_STRING \
++  "@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@"
++
+ // Branding Information
+ 
+ #define COMPANY_FULLNAME_STRING "@COMPANY_FULLNAME@"
+--- a/chrome/installer/mini_installer/mini_installer_exe_version.rc.version
++++ b/chrome/installer/mini_installer/mini_installer_exe_version.rc.version
+@@ -8,7 +8,7 @@
+ // SDK versions which causes headaches building in some environments. The
+ // VERSIONINFO resource will always be at index 1.
+ 1 VERSIONINFO
+- FILEVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
++ FILEVERSION @HELIUM_MAJOR@,@HELIUM_MINOR@,@HELIUM_PATCH@,@HELIUM_PLATFORM@
+  PRODUCTVERSION @MAJOR@,@MINOR@,@BUILD@,@PATCH@
+  FILEFLAGSMASK 0x17L
+ #ifdef _DEBUG
+@@ -26,7 +26,7 @@ BEGIN
+         BEGIN
+             VALUE "CompanyName", "@COMPANY_FULLNAME@"
+             VALUE "FileDescription", "@PRODUCT_INSTALLER_FULLNAME@"
+-            VALUE "FileVersion", "@MAJOR@.@MINOR@.@BUILD@.@PATCH@"
++            VALUE "FileVersion", "@HELIUM_MAJOR@.@HELIUM_MINOR@.@HELIUM_PATCH@.@HELIUM_PLATFORM@"
+             VALUE "InternalName", "mini_installer"
+             VALUE "LegalCopyright", "@COPYRIGHT@"
+             VALUE "ProductName", "@PRODUCT_INSTALLER_FULLNAME@"
+--- a/chrome/installer/setup/BUILD.gn
++++ b/chrome/installer/setup/BUILD.gn
+@@ -114,6 +114,7 @@ if (is_win) {
+       "//components/crash/core/common",
+       "//components/metrics:client_info",
+       "//components/metrics:metrics_pref_names",
++      "//base/version_info",
+       "//components/version_info:channel",
+       "//third_party/crashpad/crashpad/client",
+       "//third_party/crashpad/crashpad/util",
+--- a/chrome/installer/setup/install_worker.cc
++++ b/chrome/installer/setup/install_worker.cc
+@@ -34,6 +34,7 @@
+ #include "base/strings/utf_string_conversions.h"
+ #include "base/version.h"
+ #include "base/version_info/channel.h"
++#include "base/version_info/version_info.h"
+ #include "base/win/registry.h"
+ #include "base/win/security_util.h"
+ #include "base/win/sid.h"
+@@ -579,10 +580,11 @@ void AddUninstallShortcutWorkItems(const
+                                          InstallUtil::GetPublisherName(), true);
+     install_list->AddSetRegValueWorkItem(
+         reg_root, uninstall_reg, KEY_WOW64_32KEY, L"Version",
+-        ASCIIToWide(new_version.GetString()), true);
++        ASCIIToWide(version_info::GetHeliumVersionNumber()), true);
+     install_list->AddSetRegValueWorkItem(
+         reg_root, uninstall_reg, KEY_WOW64_32KEY, L"DisplayVersion",
+-        ASCIIToWide(new_version.GetString()), true);
++        ASCIIToWide(version_info::GetHeliumVersionNumber()),
++        true);
+     // TODO(wfh): Ensure that this value is preserved in the 64-bit hive when
+     // 64-bit installs place the uninstall information into the 64-bit registry.
+     install_list->AddSetRegValueWorkItem(reg_root, uninstall_reg,
+--- a/chrome/installer/setup/setup_main.cc
++++ b/chrome/installer/setup/setup_main.cc
+@@ -478,7 +478,7 @@ installer::InstallStatus RenameChromeExe
+                                     WorkItem::MoveTreeOptions{});
+ 
+   AddFinalizeUpdateWorkItems(original_state,
+-                             base::Version(chrome::kChromeVersion),
++                             base::Version(chrome::kHeliumVersion),
+                              *installer_state, setup_exe, install_list.get());
+ 
+   // Add work items to delete Chrome's "opv", "cpv", and "cmd" values.
+--- a/chrome/tools/build/win/create_installer_archive.py
++++ b/chrome/tools/build/win/create_installer_archive.py
+@@ -47,24 +47,18 @@ def BuildVersion():
+     """Returns the full build version string constructed from information in
+     VERSION_FILE.  Any segment not found in that file will default to '0'.
+     """
+-    major = 0
+-    minor = 0
+-    build = 0
+-    patch = 0
++    values = {}
+     # The version file is located at the directory ${CHROMIUM_SRC}/chrome.
+     version_file_path = os.path.join(os.path.dirname(__file__), '../../..',
+                                      VERSION_FILE)
+     for line in open(version_file_path, 'r'):
+-        line = line.rstrip()
+-        if line.startswith('MAJOR='):
+-            major = line[6:]
+-        elif line.startswith('MINOR='):
+-            minor = line[6:]
+-        elif line.startswith('BUILD='):
+-            build = line[6:]
+-        elif line.startswith('PATCH='):
+-            patch = line[6:]
+-    return '%s.%s.%s.%s' % (major, minor, build, patch)
++        key, sep, value = line.rstrip().partition('=')
++        if sep:
++            values[key] = value
++    return '%s.%s.%s.%s' % (values.get('HELIUM_MAJOR', '0'),
++                            values.get('HELIUM_MINOR', '0'),
++                            values.get('HELIUM_PATCH', '0'),
++                            values.get('HELIUM_PLATFORM', '0'))
+ 
+ 
+ def CompressUsingLZMA(build_dir,
+--- a/chrome/version.gni
++++ b/chrome/version.gni
+@@ -19,7 +19,9 @@
+ # all values we need at once.
+ _version_dictionary_template = "full = \"@MAJOR@.@MINOR@.@BUILD@.@PATCH@\" " +
+                                "major = \"@MAJOR@\" minor = \"@MINOR@\" " +
+-                               "build = \"@BUILD@\" patch = \"@PATCH@\" "
++                               "build = \"@BUILD@\" patch = \"@PATCH@\" " +
++                               "helium_full = \"@HELIUM_MAJOR@.@HELIUM_MINOR@" +
++                               ".@HELIUM_PATCH@.@HELIUM_PLATFORM@\" "
+ 
+ # The file containing the Chrome version number.
+ chrome_version_file = "//chrome/VERSION"
+@@ -160,6 +162,7 @@ _result = exec_script("//build/util/vers
+ 
+ # Full version. For example "45.0.12321.0"
+ chrome_version_full = _result.full
++helium_version_full = _result.helium_full
+ 
+ # The constituent parts of the full version.
+ chrome_version_major = _result.major
+--- a/chrome/installer/setup/last_breaking_installer_version.cc
++++ b/chrome/installer/setup/last_breaking_installer_version.cc
+@@ -11,12 +11,8 @@ namespace installer {
+ // When updating the documentation, keep a history of maximum 3 milestones prior
+ // the current version because downgrades are supported for 3 milestones.
+ //
+-// Breaking changes from 85.0.4169.0:
+-//  Change: Default installation directory for fresh 64 bits browsers moved from
+-//    base::DIR_PROGRAM_FILESX86 to DIR_PROGRAM_FILES.
+-//  Reason for being breaking: Downgrading to previous version will result in
+-//    stale data in DIR_PROGRAM_FILES since the previous installers do not know
+-//    if there is Chrome data at this location.
+-const wchar_t kLastBreakingInstallerVersion[] = L"85.0.4169.0";
++// Helium uses its own version scheme, which is below every Chromium
++// "breaking installer version".
++const wchar_t kLastBreakingInstallerVersion[] = L"0.0.0.0";
+ 
+ }  // namespace installer

--- a/patches/helium/windows/setup-chromium-version-migration.patch
+++ b/patches/helium/windows/setup-chromium-version-migration.patch
@@ -24,7 +24,7 @@
                << current_version;
 --- a/chrome/installer/setup/setup_main.cc
 +++ b/chrome/installer/setup/setup_main.cc
-@@ -1235,7 +1235,17 @@ InstallStatus InstallProductsHelper(Inst
+@@ -1308,7 +1308,17 @@ InstallStatus InstallProductsHelper(Inst
      if (!IsDowngradeAllowed(prefs)) {
        const ProductState* product_state =
            original_state.GetProductState(system_install);

--- a/patches/helium/windows/setup-chromium-version-migration.patch
+++ b/patches/helium/windows/setup-chromium-version-migration.patch
@@ -1,3 +1,27 @@
+--- a/chrome/installer/setup/downgrade_cleanup.cc
++++ b/chrome/installer/setup/downgrade_cleanup.cc
+@@ -163,6 +163,9 @@ std::wstring GetDowngradeCleanupCommandW
+ bool AddDowngradeCleanupItems(const base::Version& new_version,
+                               WorkItemList* list) {
+   DCHECK(new_version.IsValid());
++  if (!new_version.components().empty() && new_version.components().front() < 10)
++    return false;
++
+   HKEY reg_root = install_static::IsSystemInstall() ? HKEY_LOCAL_MACHINE
+                                                     : HKEY_CURRENT_USER;
+   if (GetLastBreakingInstallerVersion(reg_root) <= new_version)
+--- a/chrome/installer/setup/install.cc
++++ b/chrome/installer/setup/install.cc
+@@ -239,7 +239,8 @@ InstallStatus InstallNewVersion(const In
+   }
+ 
+   bool new_chrome_exe_exists = base::PathExists(new_chrome_exe);
+-  if (new_version > current_version) {
++  if (new_version > current_version ||
++      IsHeliumVersionSchemeMigration(current_version, new_version)) {
+     if (new_chrome_exe_exists) {
+       VLOG(1) << "Version updated to " << new_version << " while running "
+               << current_version;
 --- a/chrome/installer/setup/setup_main.cc
 +++ b/chrome/installer/setup/setup_main.cc
 @@ -1235,7 +1235,17 @@ InstallStatus InstallProductsHelper(Inst
@@ -10,11 +34,64 @@
 +      // because otherwise users updating from "148".x to 0.x.x.x will always hit
 +      // that a "higher version of chrome" is already installed.
 +      const bool is_helium_version_migration =
-+          product_state && product_state->version().components()[0] > 100 &&
-+          installer_version->components()[0] == 0;
++          product_state && IsHeliumVersionSchemeMigration(
++                               product_state->version(), *installer_version);
 +
        if (product_state != nullptr &&
 +          !is_helium_version_migration &&
            (product_state->version().CompareTo(*installer_version) > 0)) {
          LOG(ERROR) << "Higher version of Chrome is already installed.";
          int message_id = IDS_INSTALL_HIGHER_VERSION_BASE;
+--- a/chrome/installer/setup/setup_util.cc
++++ b/chrome/installer/setup/setup_util.cc
+@@ -684,6 +684,15 @@ base::FilePath GetTracingServicePath(con
+       .Append(kElevatedTracingServiceExe);
+ }
+ 
++bool IsHeliumVersionSchemeMigration(const base::Version& current_version,
++                                    const base::Version& new_version) {
++  return current_version.IsValid() && new_version.IsValid() &&
++         !current_version.components().empty() &&
++         !new_version.components().empty() &&
++         current_version.components().front() >= 100 &&
++         new_version.components().front() < 10;
++}
++
+ void AddUpdateDowngradeVersionItem(HKEY root,
+                                    const base::Version& current_version,
+                                    const base::Version& new_version,
+@@ -692,7 +701,8 @@ void AddUpdateDowngradeVersionItem(HKEY
+   DCHECK(new_version.IsValid());
+   const auto downgrade_version = InstallUtil::GetDowngradeVersion();
+   const std::wstring client_state_key = install_static::GetClientStateKeyPath();
+-  if (current_version.IsValid() && new_version < current_version) {
++  if (current_version.IsValid() && new_version < current_version &&
++      !IsHeliumVersionSchemeMigration(current_version, new_version)) {
+     // This is a downgrade. Write the value if this is the first one (i.e., no
+     // previous value exists). Otherwise, leave any existing value in place.
+     if (!downgrade_version) {
+@@ -700,8 +710,10 @@ void AddUpdateDowngradeVersionItem(HKEY
+           root, client_state_key, KEY_WOW64_32KEY, kRegDowngradeVersion,
+           base::ASCIIToWide(current_version.GetString()), true);
+     }
+-  } else if (!current_version.IsValid() || new_version >= downgrade_version) {
+-    // This is a new install or an upgrade to/past a previous DowngradeVersion.
++  } else if (!current_version.IsValid() || new_version >= downgrade_version ||
++             IsHeliumVersionSchemeMigration(current_version, new_version)) {
++    // This is a new install, an upgrade to/past a previous DowngradeVersion, or
++    // the Helium version-scheme migration (not a real downgrade).
+     list->AddDeleteRegValueWorkItem(root, client_state_key, KEY_WOW64_32KEY,
+                                     kRegDowngradeVersion);
+   }
+--- a/chrome/installer/setup/setup_util.h
++++ b/chrome/installer/setup/setup_util.h
+@@ -143,6 +143,9 @@ base::FilePath GetElevationServicePath(c
+ base::FilePath GetTracingServicePath(const base::FilePath& target_path,
+                                      const base::Version& version);
+ 
++bool IsHeliumVersionSchemeMigration(const base::Version& current_version,
++                                    const base::Version& new_version);
++
+ // Adds or removes downgrade version registry value.
+ void AddUpdateDowngradeVersionItem(HKEY root,
+                                    const base::Version& current_version,

--- a/patches/helium/windows/setup-chromium-version-migration.patch
+++ b/patches/helium/windows/setup-chromium-version-migration.patch
@@ -1,0 +1,20 @@
+--- a/chrome/installer/setup/setup_main.cc
++++ b/chrome/installer/setup/setup_main.cc
+@@ -1235,7 +1235,17 @@ InstallStatus InstallProductsHelper(Inst
+     if (!IsDowngradeAllowed(prefs)) {
+       const ProductState* product_state =
+           original_state.GetProductState(system_install);
++      // We used to ship with the versions still using the Chromium versioning,
++      // which breaks updates if we e.g. release an update while still on the same
++      // Chromium base. We migrated off those, but now we need a temporary workaround
++      // because otherwise users updating from "148".x to 0.x.x.x will always hit
++      // that a "higher version of chrome" is already installed.
++      const bool is_helium_version_migration =
++          product_state && product_state->version().components()[0] > 100 &&
++          installer_version->components()[0] == 0;
++
+       if (product_state != nullptr &&
++          !is_helium_version_migration &&
+           (product_state->version().CompareTo(*installer_version) > 0)) {
+         LOG(ERROR) << "Higher version of Chrome is already installed.";
+         int message_id = IDS_INSTALL_HIGHER_VERSION_BASE;

--- a/patches/helium/windows/updater/build-wiring.patch
+++ b/patches/helium/windows/updater/build-wiring.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -57,6 +57,7 @@ if (is_android) {
+@@ -54,6 +54,7 @@ if (is_android) {
  
  if (is_win) {
    import("//build/config/win/manifest.gni")
@@ -8,7 +8,7 @@
  }
  
  assert(!is_fuchsia, "Fuchsia shouldn't use anything in //chrome")
-@@ -103,6 +104,13 @@ buildflag_header("buildflags") {
+@@ -100,6 +101,13 @@ buildflag_header("buildflags") {
  
    if (is_win) {
      flags += [ "ENABLE_SEGMENT_HEAP=$enable_segment_heap" ]
@@ -22,7 +22,7 @@
    }
  
    # Android and ChromeOS don't support multiple browser processes, so they don't
-@@ -5834,6 +5842,17 @@ static_library("browser") {
+@@ -4069,6 +4077,17 @@ static_library("browser") {
    }
  
    if (is_win) {
@@ -72,7 +72,7 @@
  generate_allowlist_from_histograms_file("webui_name_variants") {
    namespace = "views_metrics"
    input_xml_file = "//tools/metrics/histograms/metadata/page/histograms.xml"
-@@ -3527,7 +3531,7 @@ static_library("ui") {
+@@ -3619,7 +3623,7 @@ static_library("ui") {
          "//chrome/browser/win/installer_downloader:prefs",
          "//chrome/updater/app/server/win:updater_legacy_idl",
        ]

--- a/patches/helium/windows/updater/build-wiring.patch
+++ b/patches/helium/windows/updater/build-wiring.patch
@@ -1,0 +1,243 @@
+--- a/chrome/browser/BUILD.gn
++++ b/chrome/browser/BUILD.gn
+@@ -57,6 +57,7 @@ if (is_android) {
+ 
+ if (is_win) {
+   import("//build/config/win/manifest.gni")
++  import("//chrome/updater/winsparkle.gni")
+ }
+ 
+ assert(!is_fuchsia, "Fuchsia shouldn't use anything in //chrome")
+@@ -103,6 +104,13 @@ buildflag_header("buildflags") {
+ 
+   if (is_win) {
+     flags += [ "ENABLE_SEGMENT_HEAP=$enable_segment_heap" ]
++
++    flags += [
++      "ENABLE_WINSPARKLE=$enable_winsparkle",
++      "WINSPARKLE_ED_KEY=\"$winsparkle_ed_key\"",
++      "WINSPARKLE_AUTOMATIC_CHECKS=$winsparkle_automatic_checks",
++      "WINSPARKLE_CHECK_INTERVAL=$winsparkle_check_interval",
++    ]
+   }
+ 
+   # Android and ChromeOS don't support multiple browser processes, so they don't
+@@ -5834,6 +5842,17 @@ static_library("browser") {
+   }
+ 
+   if (is_win) {
++    if (enable_winsparkle) {
++      sources += [
++        "win/winsparkle_glue.cc",
++        "win/winsparkle_glue.h",
++      ]
++      deps += [
++        "//components/helium_services",
++        "//third_party/winsparkle",
++      ]
++    }
++
+     libs += [
+       "secur32.lib",
+ 
+--- a/chrome/browser/buildflags.gni
++++ b/chrome/browser/buildflags.gni
+@@ -3,6 +3,9 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chrome_build.gni")
++if (is_win) {
++  import("//chrome/updater/winsparkle.gni")
++}
+ 
+ # IMPORTANT
+ # We are not accepting any new build flags in //chrome. See
+@@ -17,5 +20,5 @@ declare_args() {
+ 
+   # Detect updates and notify the user for Google Chrome across all platforms.
+   # Chromium does not use an auto-updater.
+-  enable_update_notifications = is_chrome_branded
++  enable_update_notifications = enable_winsparkle
+ }
+--- a/chrome/browser/ui/BUILD.gn
++++ b/chrome/browser/ui/BUILD.gn
+@@ -31,6 +31,10 @@ import("//ui/views/features.gni")
+ assert(enable_supervised_users)
+ assert(!is_fuchsia, "Fuchsia shouldn't use anything in //chrome")
+ 
++if (is_win) {
++  import("//chrome/updater/winsparkle.gni")
++}
++
+ generate_allowlist_from_histograms_file("webui_name_variants") {
+   namespace = "views_metrics"
+   input_xml_file = "//tools/metrics/histograms/metadata/page/histograms.xml"
+@@ -3527,7 +3531,7 @@ static_library("ui") {
+         "//chrome/browser/win/installer_downloader:prefs",
+         "//chrome/updater/app/server/win:updater_legacy_idl",
+       ]
+-    } else {
++    } else if (!enable_winsparkle) {
+       sources += [ "webui/help/version_updater_basic.cc" ]
+     }
+   }
+--- a/chrome/installer/mini_installer/chrome.release
++++ b/chrome/installer/mini_installer/chrome.release
+@@ -36,6 +36,7 @@ vk_swiftshader.dll: %(VersionDir)s\
+ vk_swiftshader_icd.json: %(VersionDir)s\
+ vulkan-1.dll: %(VersionDir)s\
+ v8_context_snapshot.bin: %(VersionDir)s\
++WinSparkle.dll: %(VersionDir)s\
+ #
+ # Sub directories living in the version dir
+ #
+--- a/chrome/tools/build/win/FILES.cfg
++++ b/chrome/tools/build/win/FILES.cfg
+@@ -79,6 +79,12 @@ FILES = [
+     'filegroup': ['default'],
+   },
+   {
++    'filename': 'WinSparkle.dll',
++    'buildtype': ['dev', 'official'],
++    'filegroup': ['default'],
++    'optional': ['dev', 'official'],
++  },
++  {
+     'filename': '*.manifest',
+     'buildtype': ['official'],
+     'filegroup': ['default'],
+--- /dev/null
++++ b/chrome/updater/winsparkle.gni
+@@ -0,0 +1,13 @@
++# Copyright 2026 The Helium Authors
++# You can use, redistribute, and/or modify this source code under
++# the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++declare_args() {
++  enable_winsparkle = false
++  winsparkle_ed_key = ""
++  winsparkle_automatic_checks = true
++  winsparkle_check_interval = 3600
++
++  # Must match the Subject Organization (O= field) of the signing cert.
++  winsparkle_authenticode_org = ""
++}
+--- a/infra/archive_config/win-archive-rel.json
++++ b/infra/archive_config/win-archive-rel.json
+@@ -33,7 +33,8 @@
+                 "v8_context_snapshot.bin",
+                 "vk_swiftshader.dll",
+                 "vk_swiftshader_icd.json",
+-                "vulkan-1.dll"
++                "vulkan-1.dll",
++                "WinSparkle.dll"
+             ],
+             "file_globs": [
+                 "locales\\*.pak",
+--- /dev/null
++++ b/third_party/winsparkle/BUILD.gn
+@@ -0,0 +1,73 @@
++# Copyright 2026 The Helium Authors
++# You can use, redistribute, and/or modify this source code under
++# the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++assert(is_win)
++
++config("winsparkle_config") {
++  defines = [ "WIN_SPARKLE_NO_AUTOLINK" ]
++  include_dirs = [ "include" ]
++}
++
++config("winsparkle_delayload") {
++  ldflags = [ "/DELAYLOAD:WinSparkle.dll" ]
++}
++
++shared_library("winsparkle") {
++  output_name = "WinSparkle"
++
++  sources = [
++    "src/appcast.cpp",
++    "src/appcontroller.cpp",
++    "src/dll_api.cpp",
++    "src/dllmain.cpp",
++    "src/download.cpp",
++    "src/error.cpp",
++    "src/settings.cpp",
++    "src/signatureverifier.cpp",
++    "src/threads.cpp",
++    "src/ui_headless.cpp",  # headless replacement for src/ui.cpp.
++    "src/updatechecker.cpp",
++    "src/updatedownloader.cpp",
++    "src/winsparkle.rc",
++  ]
++
++  include_dirs = [
++    "include",
++    "src",
++  ]
++
++  defines = [ "BUILDING_WIN_SPARKLE" ]
++
++  deps = [
++    "//third_party/boringssl",
++    "//third_party/expat",
++  ]
++
++  libs = [
++    "advapi32.lib",
++    "crypt32.lib",
++    "ole32.lib",
++    "rpcrt4.lib",
++    "shell32.lib",
++    "user32.lib",
++    "wininet.lib",
++  ]
++
++  configs -= [
++    "//build/config/compiler:chromium_code",
++    "//build/config/compiler:no_exceptions",
++  ]
++  configs += [
++    "//build/config/compiler:no_chromium_code",
++    "//build/config/compiler:exceptions",
++  ]
++
++  cflags_cc = [
++    "-Wno-misleading-indentation",  # appcast.cpp
++    "-Wno-reorder-ctor",            # updatedownloader.cpp
++  ]
++
++  public_configs = [ ":winsparkle_config" ]
++  all_dependent_configs = [ ":winsparkle_delayload" ]
++}
+--- /dev/null
++++ b/third_party/winsparkle/README.chromium
+@@ -0,0 +1,13 @@
++Name: WinSparkle
++Short Name: winsparkle
++URL: https://github.com/vslavik/winsparkle
++License: MIT
++License File: COPYING
++Shipped: yes
++Security Critical: yes
++
++Description:
++Used for Windows autoupdates.
++
++Local Modifications:
++Ripped out all UI logic, old DSA signing logic, and dependencies thereof.
+--- a/third_party/winsparkle/include/winsparkle.h
++++ b/third_party/winsparkle/include/winsparkle.h
+@@ -31,7 +31,11 @@
+ 
+ #include "winsparkle-version.h"
+ 
+-#if !defined(BUILDING_WIN_SPARKLE) && defined(_MSC_VER)
++// WIN_SPARKLE_NO_AUTOLINK lets GN link the import library explicitly
++// via the build system instead of via this pragma whose hard-coded name
++// may not match the GN import lib.
++#if !defined(BUILDING_WIN_SPARKLE) && !defined(WIN_SPARKLE_NO_AUTOLINK) && \
++    defined(_MSC_VER)
+ #pragma comment(lib, "WinSparkle.lib")
+ #endif
+ 

--- a/patches/helium/windows/updater/fixup-wrong-version.patch
+++ b/patches/helium/windows/updater/fixup-wrong-version.patch
@@ -1,0 +1,63 @@
+--- a/chrome/browser/upgrade_detector/get_installed_version_win.cc
++++ b/chrome/browser/upgrade_detector/get_installed_version_win.cc
+@@ -11,10 +11,51 @@
+ #include "base/location.h"
+ #include "base/task/task_traits.h"
+ #include "base/task/thread_pool.h"
++#include "chrome/browser/buildflags.h"
++
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++#include <windows.h>
++
++#include <vector>
++
++#include "base/base_paths.h"
++#include "base/files/file_path.h"
++#include "base/path_service.h"
++#include "base/version.h"
++#include "base/version_info/version_info.h"
++#include "chrome/installer/util/util_constants.h"
++#else
+ #include "chrome/installer/util/install_util.h"
++#endif
+ 
+ namespace {
+ 
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++
++// Duplicated helium::HasPendingUpdateSwap() here rather than shared to
++// avoid an upgrade_detector -> //chrome/browser circular dependency.
++bool HasPendingUpdateSwap() {
++  base::FilePath dir;
++  if (!base::PathService::Get(base::DIR_EXE, &dir)) {
++    return false;
++  }
++  return ::GetFileAttributesW(
++             dir.Append(installer::kChromeNewExe).value().c_str()) !=
++         INVALID_FILE_ATTRIBUTES;
++}
++
++InstalledAndCriticalVersion GetInstalledVersionSynchronous() {
++  base::Version running = version_info::GetVersion();
++  if (HasPendingUpdateSwap() && running.IsValid()) {
++    std::vector<uint32_t> components = running.components();
++    components.back() += 1;
++    return InstalledAndCriticalVersion(base::Version(std::move(components)));
++  }
++  return InstalledAndCriticalVersion(std::move(running));
++}
++
++#else  // !BUILDFLAG(ENABLE_WINSPARKLE)
++
+ InstalledAndCriticalVersion GetInstalledVersionSynchronous() {
+   base::Version installed_version =
+       InstallUtil::GetChromeVersion(!InstallUtil::IsPerUserInstall());
+@@ -28,6 +69,8 @@ InstalledAndCriticalVersion GetInstalled
+   return InstalledAndCriticalVersion(std::move(installed_version));
+ }
+ 
++#endif  // BUILDFLAG(ENABLE_WINSPARKLE)
++
+ }  // namespace
+ 
+ void GetInstalledVersion(InstalledVersionCallback callback) {

--- a/patches/helium/windows/updater/fixup-wrong-version.patch
+++ b/patches/helium/windows/updater/fixup-wrong-version.patch
@@ -61,3 +61,21 @@
  }  // namespace
  
  void GetInstalledVersion(InstalledVersionCallback callback) {
+--- a/chrome/installer/setup/last_breaking_installer_version.cc
++++ b/chrome/installer/setup/last_breaking_installer_version.cc
+@@ -11,12 +11,8 @@ namespace installer {
+ // When updating the documentation, keep a history of maximum 3 milestones prior
+ // the current version because downgrades are supported for 3 milestones.
+ //
+-// Breaking changes from 85.0.4169.0:
+-//  Change: Default installation directory for fresh 64 bits browsers moved from
+-//    base::DIR_PROGRAM_FILESX86 to DIR_PROGRAM_FILES.
+-//  Reason for being breaking: Downgrading to previous version will result in
+-//    stale data in DIR_PROGRAM_FILES since the previous installers do not know
+-//    if there is Chrome data at this location.
+-const wchar_t kLastBreakingInstallerVersion[] = L"85.0.4169.0";
++// Helium uses its own version scheme, which is below every Chromium
++// "breaking installer version".
++const wchar_t kLastBreakingInstallerVersion[] = L"0.0.0.0";
+ 
+ }  // namespace installer

--- a/patches/helium/windows/updater/glue.patch
+++ b/patches/helium/windows/updater/glue.patch
@@ -1,0 +1,532 @@
+--- /dev/null
++++ b/chrome/browser/win/winsparkle_glue.cc
+@@ -0,0 +1,506 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "chrome/browser/win/winsparkle_glue.h"
++
++#include <windows.h>
++
++#include <shellapi.h>
++
++#include <algorithm>
++#include <atomic>
++#include <memory>
++#include <string>
++
++#include "base/base_paths.h"
++#include "base/callback_list.h"
++#include "base/command_line.h"
++#include "base/files/file_path.h"
++#include "base/functional/bind.h"
++#include "base/location.h"
++#include "base/logging.h"
++#include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
++#include "base/no_destructor.h"
++#include "base/path_service.h"
++#include "base/process/launch.h"
++#include "base/scoped_observation.h"
++#include "base/strings/string_number_conversions.h"
++#include "base/strings/utf_string_conversions.h"
++#include "base/version_info/version_info.h"
++#include "chrome/browser/browser_process.h"
++#include "chrome/browser/buildflags.h"
++#include "chrome/browser/profiles/profile.h"
++#include "chrome/browser/profiles/profile_manager.h"
++#include "chrome/browser/profiles/profile_manager_observer.h"
++#include "chrome/browser/profiles/profile_observer.h"
++#include "chrome/browser/ui/webui/help/version_updater.h"
++#include "chrome/grit/generated_resources.h"
++#include "chrome/install_static/install_util.h"
++#include "chrome/installer/util/util_constants.h"
++#include "components/helium_services/helium_services_helpers.h"
++#include "components/helium_services/pref_names.h"
++#include "components/prefs/pref_change_registrar.h"
++#include "components/prefs/pref_service.h"
++#include "content/public/browser/browser_task_traits.h"
++#include "content/public/browser/browser_thread.h"
++#include "content/public/browser/web_contents.h"
++#include "third_party/winsparkle/include/winsparkle.h"
++#include "ui/base/l10n/l10n_util.h"
++#include "url/gurl.h"
++
++namespace helium {
++
++namespace {
++
++std::atomic<bool> g_nearly_updated{false};
++std::wstring& PendingSystemPayload() {
++  static base::NoDestructor<std::wstring> path;
++  return *path;
++}
++std::wstring& PendingSystemSignature() {
++  static base::NoDestructor<std::wstring> sig;
++  return *sig;
++}
++
++bool HasPendingUpdateSwap() {
++  base::FilePath dir;
++  if (!base::PathService::Get(base::DIR_EXE, &dir)) {
++    return false;
++  }
++  const base::FilePath new_exe = dir.Append(installer::kChromeNewExe);
++  return ::GetFileAttributesW(new_exe.value().c_str()) !=
++         INVALID_FILE_ATTRIBUTES;
++}
++
++bool RunPerUserInstallerWait(const std::wstring& installer_path) {
++  base::CommandLine command_line{base::FilePath(installer_path)};
++  command_line.AppendSwitch("do-not-launch-chrome");
++  base::Process process =
++      base::LaunchProcess(command_line, base::LaunchOptions());
++  if (!process.IsValid()) {
++    LOG(ERROR) << "WinSparkle: failed to launch per-user update installer";
++    return false;
++  }
++
++  int exit_code = -1;
++  if (!process.WaitForExit(&exit_code) || exit_code != 0) {
++    LOG(ERROR) << "WinSparkle: per-user installer failed, exit code "
++               << exit_code;
++    return false;
++  }
++  return true;
++}
++
++// Maps WinSparkle's status callbacks onto VersionUpdater::Status.
++class WinSparkleStatusBroadcaster {
++ public:
++  using StatusCallbackList = base::RepeatingCallbackList<
++      void(VersionUpdater::Status, int progress, const std::u16string&)>;
++
++  static WinSparkleStatusBroadcaster& GetInstance() {
++    static base::NoDestructor<WinSparkleStatusBroadcaster> instance;
++    return *instance;
++  }
++
++  base::CallbackListSubscription Subscribe(
++      StatusCallbackList::CallbackType callback) {
++    return callbacks_.Add(std::move(callback));
++  }
++
++  void Notify(VersionUpdater::Status status,
++              int progress,
++              const std::u16string& message) {
++    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++    callbacks_.Notify(status, progress, message);
++  }
++
++ private:
++  StatusCallbackList callbacks_;
++};
++
++void PostStatus(VersionUpdater::Status status,
++                int progress = 0,
++                const std::u16string& message = std::u16string()) {
++  content::GetUIThreadTaskRunner({})->PostTask(
++      FROM_HERE,
++      base::BindOnce(
++          &WinSparkleStatusBroadcaster::Notify,
++          base::Unretained(&WinSparkleStatusBroadcaster::GetInstance()), status,
++          progress, message));
++}
++
++// WinSparkle C callbacks
++void __cdecl OnDidFindUpdate() {
++  PostStatus(VersionUpdater::UPDATING);
++}
++
++void __cdecl OnDidNotFindUpdate() {
++  PostStatus(VersionUpdater::UPDATED);
++}
++
++void __cdecl OnUpdateError() {
++  char buf[512] = {};
++  win_sparkle_get_last_error_message(buf, sizeof(buf));
++  const std::string message(buf);
++  LOG(ERROR) << "WinSparkle update error: "
++             << (message.empty() ? "(no detail)" : message.c_str());
++  if (message.empty()) {
++    PostStatus(VersionUpdater::FAILED);
++  } else {
++    PostStatus(VersionUpdater::FAILED, /*progress=*/0,
++               base::UTF8ToUTF16(message));
++  }
++}
++
++void __cdecl OnDownloadProgress(size_t downloaded, size_t total) {
++  size_t percent = 0;
++  if (total > 0) {
++    percent = std::clamp<size_t>(downloaded * 100 / total, 0, 100);
++  }
++  PostStatus(VersionUpdater::UPDATING, static_cast<int>(percent));
++}
++
++void StorePendingSystemUpdate(const std::wstring& payload,
++                              const std::wstring& signature) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  PendingSystemPayload() = payload;
++  PendingSystemSignature() = signature;
++  g_nearly_updated.store(true, std::memory_order_release);
++  WinSparkleStatusBroadcaster::GetInstance().Notify(
++      VersionUpdater::NEARLY_UPDATED, /*progress=*/0, std::u16string());
++}
++
++// Invoked by WinSparkle once the update payload is downloaded and verified.
++// Returning 1 tells WinSparkle we handled installation and it must not relaunch
++// the app; the new version is applied on the next relaunch.
++int __cdecl OnRunInstaller(const wchar_t* file_path) {
++  if (install_static::IsSystemInstall()) {
++    // System installs need elevation. We do not elevate now, instead record
++    // the verified payload and apply it only when the user clicks Relaunch.
++    char sig[256] = {};
++    win_sparkle_get_pending_update_eddsa_signature(sig, sizeof(sig));
++    content::GetUIThreadTaskRunner({})->PostTask(
++        FROM_HERE,
++        base::BindOnce(&StorePendingSystemUpdate, std::wstring(file_path),
++                       base::UTF8ToWide(std::string(sig))));
++    return 1;
++  }
++
++  // Per-user: no elevation needed. Stage the update silently now.
++  if (!RunPerUserInstallerWait(file_path) || !HasPendingUpdateSwap()) {
++    PostStatus(VersionUpdater::FAILED);
++    return WINSPARKLE_RETURN_ERROR;
++  }
++
++  g_nearly_updated.store(true, std::memory_order_release);
++  PostStatus(VersionUpdater::NEARLY_UPDATED);
++  return 1;
++}
++
++void RegisterWinSparkleCallbacks() {
++  win_sparkle_set_did_find_update_callback(&OnDidFindUpdate);
++  win_sparkle_set_did_not_find_update_callback(&OnDidNotFindUpdate);
++  win_sparkle_set_error_callback(&OnUpdateError);
++  win_sparkle_set_download_progress_callback(&OnDownloadProgress);
++  win_sparkle_set_user_run_installer_callback(&OnRunInstaller);
++}
++
++void ApplyAppcastUrl(PrefService* prefs) {
++  const GURL feed = helium::GetBrowserUpdateURL(*prefs);
++  if (feed.is_valid()) {
++    win_sparkle_set_appcast_url(feed.spec().c_str());
++  }
++}
++
++class WinSparkleController : public ProfileObserver,
++                             public ProfileManagerObserver {
++ public:
++  static WinSparkleController& GetInstance() {
++    static base::NoDestructor<WinSparkleController> instance;
++    return *instance;
++  }
++
++  void Start(Profile* initial_profile) {
++    if (started_) {
++      return;
++    }
++    started_ = true;
++    if (ProfileManager* manager = GetProfileManager()) {
++      profile_manager_observation_.Observe(manager);
++    }
++    AcquireProfile(initial_profile, /*exclude=*/nullptr);
++  }
++
++  // ProfileManagerObserver:
++  void OnProfileAdded(Profile* new_profile) override {
++    if (!profile_) {
++      AcquireProfile(new_profile, /*exclude=*/nullptr);
++    } else if (!ProfileCanUpdate(profile_) && ProfileCanUpdate(new_profile) &&
++               IsCandidate(new_profile)) {
++      // The active profile isn't asking for updates but this new
++      // one is; let it take over.
++      Unbind();
++      Bind(new_profile);
++    }
++  }
++
++  void OnProfileManagerDestroying() override {
++    profile_manager_observation_.Reset();
++  }
++
++  // ProfileObserver:
++  void OnProfileWillBeDestroyed(Profile* profile) override {
++    DCHECK_EQ(profile, profile_);
++    Unbind();
++    AcquireProfile(/*preferred=*/nullptr, /*exclude=*/profile);
++  }
++
++ private:
++  friend class base::NoDestructor<WinSparkleController>;
++  WinSparkleController() = default;
++  ~WinSparkleController() override = default;
++
++  static ProfileManager* GetProfileManager() {
++    return g_browser_process ? g_browser_process->profile_manager() : nullptr;
++  }
++
++  static bool IsCandidate(Profile* profile) {
++    return profile && profile->IsRegularProfile();
++  }
++
++  static bool ProfileCanUpdate(Profile* profile) {
++    return profile && helium::ShouldAccessUpdateService(*profile->GetPrefs());
++  }
++
++  // Adopts a profile to drive updates if none is active. No-op if one
++  // is already active or none qualifies.
++  void AcquireProfile(Profile* preferred, Profile* exclude) {
++    if (profile_) {
++      return;
++    }
++
++    if (preferred != exclude && IsCandidate(preferred)) {
++      Bind(preferred);
++      return;
++    }
++
++    ProfileManager* manager = GetProfileManager();
++    if (!manager) {
++      return;
++    }
++
++    Profile* fallback = nullptr;
++    for (Profile* profile : manager->GetLoadedProfiles()) {
++      if (profile == exclude || !IsCandidate(profile)) {
++        continue;
++      }
++      if (ProfileCanUpdate(profile)) {
++        Bind(profile);
++        return;
++      }
++      if (!fallback) {
++        fallback = profile;
++      }
++    }
++    if (fallback) {
++      Bind(fallback);
++    }
++  }
++
++  void Bind(Profile* profile) {
++    DCHECK(!profile_);
++    profile_ = profile;
++    profile_observation_.Observe(profile);
++    registrar_.Init(profile->GetPrefs());
++    helium::ConfigurePrefChangeRegistrarFor(
++        prefs::kHeliumUpdateFetchingEnabled, registrar_,
++        base::BindRepeating(&WinSparkleController::ApplyUpdaterState,
++                            base::Unretained(this)));
++    ApplyUpdaterState();
++  }
++
++  void Unbind() {
++    registrar_.RemoveAll();
++    profile_observation_.Reset();
++    profile_ = nullptr;
++    win_sparkle_set_automatic_check_for_updates(0);
++  }
++
++  void ApplyUpdaterState() {
++    if (!profile_) {
++      return;
++    }
++    PrefService* prefs = profile_->GetPrefs();
++    const bool consented = helium::ShouldAccessUpdateService(*prefs);
++
++    if (!initialized_) {
++      if (!consented) {
++        return;
++      }
++      initialized_ = true;
++
++      base::FilePath module_dir;
++      if (base::PathService::Get(base::DIR_MODULE, &module_dir)) {
++        ::LoadLibraryW(
++            module_dir.Append(FILE_PATH_LITERAL("WinSparkle.dll"))
++                .value()
++                .c_str());
++      }
++
++      const std::wstring version =
++          base::UTF8ToWide(std::string(version_info::GetHeliumVersionNumber()));
++      win_sparkle_set_app_details(L"Helium", L"Helium", version.c_str());
++      win_sparkle_set_eddsa_public_key(BUILDFLAG(WINSPARKLE_ED_KEY));
++      RegisterWinSparkleCallbacks();
++      win_sparkle_set_update_check_interval(
++          BUILDFLAG(WINSPARKLE_CHECK_INTERVAL));
++      win_sparkle_set_automatic_check_for_updates(
++          BUILDFLAG(WINSPARKLE_AUTOMATIC_CHECKS));
++
++      ApplyAppcastUrl(prefs);
++      win_sparkle_init();
++      return;
++    }
++
++    // Already running: reflect the current consent live (no re-init).
++    ApplyAppcastUrl(prefs);
++    win_sparkle_set_automatic_check_for_updates(
++        consented ? BUILDFLAG(WINSPARKLE_AUTOMATIC_CHECKS) : 0);
++  }
++
++  raw_ptr<Profile> profile_ = nullptr;
++  bool initialized_ = false;
++  bool started_ = false;
++  PrefChangeRegistrar registrar_;
++  base::ScopedObservation<Profile, ProfileObserver> profile_observation_{this};
++  base::ScopedObservation<ProfileManager, ProfileManagerObserver>
++      profile_manager_observation_{this};
++};
++
++class VersionUpdaterWinSparkle : public VersionUpdater {
++ public:
++  explicit VersionUpdaterWinSparkle(bool enabled) : enabled_(enabled) {
++    subscription_ = WinSparkleStatusBroadcaster::GetInstance().Subscribe(
++        base::BindRepeating(&VersionUpdaterWinSparkle::OnStatus,
++                            weak_factory_.GetWeakPtr()));
++  }
++
++  VersionUpdaterWinSparkle(const VersionUpdaterWinSparkle&) = delete;
++  VersionUpdaterWinSparkle& operator=(const VersionUpdaterWinSparkle&) = delete;
++
++  ~VersionUpdaterWinSparkle() override = default;
++
++  // VersionUpdater:
++  void CheckForUpdate(StatusCallback status_callback,
++                      PromoteCallback /*promote_callback*/) override {
++    status_callback_ = std::move(status_callback);
++
++    if (!enabled_) {
++      RunStatus(DISABLED);
++      return;
++    }
++
++    if (ApplicationIsNearlyUpdated()) {
++      RunStatus(NEARLY_UPDATED);
++      return;
++    }
++
++    RunStatus(CHECKING);
++    win_sparkle_check_update_with_ui_and_install();
++  }
++
++ private:
++  void RunStatus(Status status,
++                 int progress = 0,
++                 const std::u16string& message = {}) {
++    if (status_callback_.is_null()) {
++      return;
++    }
++    status_callback_.Run(status, progress, /*rollback=*/false,
++                         /*powerwash=*/false, /*version=*/std::string(),
++                         /*update_size=*/0, message);
++  }
++
++  void OnStatus(VersionUpdater::Status status,
++                int progress,
++                const std::u16string& message) {
++    RunStatus(status, progress, message);
++  }
++
++  const bool enabled_;
++  StatusCallback status_callback_;
++  base::CallbackListSubscription subscription_;
++  base::WeakPtrFactory<VersionUpdaterWinSparkle> weak_factory_{this};
++};
++
++}  // namespace
++
++bool WinSparkleEnabled(PrefService* prefs) {
++  return prefs && helium::ShouldAccessUpdateService(*prefs);
++}
++
++void InitializeWinSparkle(Profile* profile) {
++  WinSparkleController::GetInstance().Start(profile);
++}
++
++bool ApplicationIsNearlyUpdated() {
++  return g_nearly_updated.load(std::memory_order_acquire) ||
++         HasPendingUpdateSwap();
++}
++
++bool MaybeElevateSystemUpdateOnRelaunch() {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++
++  // Per-user installs apply with no elevation.
++  if (!install_static::IsSystemInstall()) {
++    return false;
++  }
++
++  // No verified system update waiting.
++  if (PendingSystemPayload().empty()) {
++    return false;
++  }
++
++  // The apply helper ships next to chrome.dll in the version dir.
++  base::FilePath module_dir;
++  if (!base::PathService::Get(base::DIR_MODULE, &module_dir)) {
++    return false;
++  }
++  const base::FilePath helper =
++      module_dir.Append(FILE_PATH_LITERAL("helium_update_helper.exe"));
++
++  const std::wstring params = L"--payload=\"" + PendingSystemPayload() +
++                              L"\" --signature=\"" + PendingSystemSignature() +
++                              L"\" --wait-pid=" +
++                              base::NumberToWString(::GetCurrentProcessId());
++
++  SHELLEXECUTEINFOW sei = {sizeof(sei)};
++  sei.fMask = SEE_MASK_NOASYNC;
++  sei.lpVerb = L"runas";
++  sei.lpFile = helper.value().c_str();
++  sei.lpParameters = params.c_str();
++  sei.nShow = SW_SHOWNORMAL;
++  if (!::ShellExecuteExW(&sei)) {
++    LOG(WARNING) << "WinSparkle: elevated update apply not started, err="
++                 << ::GetLastError();
++    return false;
++  }
++  return true;
++}
++
++}  // namespace helium
++
++std::unique_ptr<VersionUpdater> VersionUpdater::Create(
++    content::WebContents* web_contents) {
++  PrefService* prefs = nullptr;
++  if (web_contents) {
++    if (auto* profile =
++            Profile::FromBrowserContext(web_contents->GetBrowserContext())) {
++      prefs = profile->GetPrefs();
++    }
++  }
++  return std::make_unique<helium::VersionUpdaterWinSparkle>(
++      helium::WinSparkleEnabled(prefs));
++}
+--- /dev/null
++++ b/chrome/browser/win/winsparkle_glue.h
+@@ -0,0 +1,20 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_WIN_WINSPARKLE_GLUE_H_
++#define CHROME_BROWSER_WIN_WINSPARKLE_GLUE_H_
++
++class PrefService;
++class Profile;
++
++namespace helium {
++
++bool WinSparkleEnabled(PrefService* prefs);
++void InitializeWinSparkle(Profile* profile);
++bool ApplicationIsNearlyUpdated();
++bool MaybeElevateSystemUpdateOnRelaunch();
++
++}  // namespace helium
++
++#endif  // CHROME_BROWSER_WIN_WINSPARKLE_GLUE_H_

--- a/patches/helium/windows/updater/glue.patch
+++ b/patches/helium/windows/updater/glue.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/chrome/browser/win/winsparkle_glue.cc
-@@ -0,0 +1,506 @@
+@@ -0,0 +1,547 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -20,6 +20,7 @@
 +#include "base/callback_list.h"
 +#include "base/command_line.h"
 +#include "base/files/file_path.h"
++#include "base/files/file_util.h"
 +#include "base/functional/bind.h"
 +#include "base/location.h"
 +#include "base/logging.h"
@@ -28,9 +29,12 @@
 +#include "base/no_destructor.h"
 +#include "base/path_service.h"
 +#include "base/process/launch.h"
++#include "base/process/process.h"
 +#include "base/scoped_observation.h"
 +#include "base/strings/string_number_conversions.h"
 +#include "base/strings/utf_string_conversions.h"
++#include "base/task/thread_pool.h"
++#include "base/time/time.h"
 +#include "base/version_info/version_info.h"
 +#include "chrome/browser/browser_process.h"
 +#include "chrome/browser/buildflags.h"
@@ -39,6 +43,7 @@
 +#include "chrome/browser/profiles/profile_manager_observer.h"
 +#include "chrome/browser/profiles/profile_observer.h"
 +#include "chrome/browser/ui/webui/help/version_updater.h"
++#include "chrome/common/chrome_paths.h"
 +#include "chrome/grit/generated_resources.h"
 +#include "chrome/install_static/install_util.h"
 +#include "chrome/installer/util/util_constants.h"
@@ -75,6 +80,37 @@
 +  const base::FilePath new_exe = dir.Append(installer::kChromeNewExe);
 +  return ::GetFileAttributesW(new_exe.value().c_str()) !=
 +         INVALID_FILE_ATTRIBUTES;
++}
++
++base::FilePath SystemUpdateMarkerPath() {
++  base::FilePath dir;
++  if (!base::PathService::Get(chrome::DIR_USER_DATA, &dir)) {
++    return base::FilePath();
++  }
++  return dir.Append(FILE_PATH_LITERAL("PendingSystemUpdate"));
++}
++
++std::string SessionToken() {
++  return base::NumberToString(base::Process::Current()
++                                  .CreationTime()
++                                  .ToDeltaSinceWindowsEpoch()
++                                  .InMicroseconds());
++}
++
++void MarkSystemUpdatePending() {
++  const base::FilePath path = SystemUpdateMarkerPath();
++  if (!path.empty()) {
++    base::WriteFile(path, SessionToken());
++  }
++}
++
++void ClearStaleSystemUpdateMarker() {
++  const base::FilePath path = SystemUpdateMarkerPath();
++  std::string token;
++  if (!path.empty() && base::ReadFileToString(path, &token) &&
++      token != SessionToken()) {
++    base::DeleteFile(path);
++  }
 +}
 +
 +bool RunPerUserInstallerWait(const std::wstring& installer_path) {
@@ -184,6 +220,8 @@
 +    // the verified payload and apply it only when the user clicks Relaunch.
 +    char sig[256] = {};
 +    win_sparkle_get_pending_update_eddsa_signature(sig, sizeof(sig));
++    // Drop the marker the update chip polls for.
++    MarkSystemUpdatePending();
 +    content::GetUIThreadTaskRunner({})->PostTask(
 +        FROM_HERE,
 +        base::BindOnce(&StorePendingSystemUpdate, std::wstring(file_path),
@@ -230,6 +268,9 @@
 +      return;
 +    }
 +    started_ = true;
++    base::ThreadPool::PostTask(
++        FROM_HERE, {base::MayBlock(), base::TaskPriority::BEST_EFFORT},
++        base::BindOnce(&ClearStaleSystemUpdateMarker));
 +    if (ProfileManager* manager = GetProfileManager()) {
 +      profile_manager_observation_.Observe(manager);
 +    }

--- a/patches/helium/windows/updater/helper.patch
+++ b/patches/helium/windows/updater/helper.patch
@@ -1,0 +1,696 @@
+--- a/chrome/browser/BUILD.gn
++++ b/chrome/browser/BUILD.gn
+@@ -5851,6 +5851,7 @@ static_library("browser") {
+         "//components/helium_services",
+         "//third_party/winsparkle",
+       ]
++      data_deps = [ "//chrome/installer/helium_update_helper" ]
+     }
+ 
+     libs += [
+--- /dev/null
++++ b/chrome/installer/helium_update_helper/BUILD.gn
+@@ -0,0 +1,57 @@
++# Copyright 2026 The Helium Authors
++# You can use, redistribute, and/or modify this source code under
++# the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++import("//build/config/win/manifest.gni")
++import("//chrome/updater/winsparkle.gni")
++
++assert(is_win)
++
++windows_manifest("helium_update_helper_manifest") {
++  sources = [
++    as_invoker_manifest,
++    common_controls_manifest,
++  ]
++}
++
++executable("helium_update_helper") {
++  output_name = "helium_update_helper"
++
++  sources = [
++    "event_log.cc",
++    "helium_update_helper.h",
++    "helium_update_helper.rc",
++    "helium_update_helper_main.cc",
++    "localized_strings.cc",
++    "payload_verifier.cc",
++    "progress_dialog.cc",
++    "update_installer.cc",
++  ]
++
++  inputs = [ "//chrome/app/theme/chromium/win/chromium.ico" ]
++
++  configs -= [ "//build/config/win:console" ]
++  configs += [ "//build/config/win:windowed" ]
++
++  deps = [
++    ":helium_update_helper_manifest",
++    "//base",
++    "//chrome/installer/util:strings",
++    "//third_party/boringssl",
++  ]
++
++  defines = [
++    "HELIUM_AUTHENTICODE_ORG=L\"$winsparkle_authenticode_org\"",
++    "HELIUM_EDDSA_PUBKEY=\"$winsparkle_ed_key\"",
++  ]
++
++  libs = [
++    "advapi32.lib",
++    "comctl32.lib",
++    "crypt32.lib",
++    "ole32.lib",
++    "oleaut32.lib",
++    "shell32.lib",
++    "wintrust.lib",
++  ]
++}
+--- /dev/null
++++ b/chrome/installer/helium_update_helper/event_log.cc
+@@ -0,0 +1,24 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "chrome/installer/helium_update_helper/helium_update_helper_internal.h"
++
++namespace helium_updater {
++
++namespace {
++constexpr wchar_t kEventSource[] = L"HeliumUpdateHelper";
++}  // namespace
++
++void LogEvent(WORD type, const std::wstring& message) {
++  HANDLE source = ::RegisterEventSourceW(nullptr, kEventSource);
++  if (!source) {
++    return;
++  }
++  const wchar_t* strings[1] = {message.c_str()};
++  ::ReportEventW(source, type, /*category=*/0, /*event_id=*/0, /*sid=*/nullptr,
++                 /*num_strings=*/1, /*data_size=*/0, strings, /*data=*/nullptr);
++  ::DeregisterEventSource(source);
++}
++
++}  // namespace helium_updater
+--- /dev/null
++++ b/chrome/installer/helium_update_helper/helium_update_helper.rc
+@@ -0,0 +1,5 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++1 ICON "..\\..\\app\\theme\\chromium\\win\\chromium.ico"
+--- /dev/null
++++ b/chrome/installer/helium_update_helper/helium_update_helper_internal.h
+@@ -0,0 +1,68 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef CHROME_INSTALLER_HELIUM_UPDATE_HELPER_HELIUM_UPDATE_HELPER_INTERNAL_H_
++#define CHROME_INSTALLER_HELIUM_UPDATE_HELPER_HELIUM_UPDATE_HELPER_INTERNAL_H_
++
++#include <windows.h>
++
++#include <cstdint>
++#include <string>
++
++#include "base/containers/span.h"
++#include "base/files/file_path.h"
++
++namespace helium_updater {
++
++// Process exit codes, also returned by ApplyUpdate.
++enum ExitCode {
++  kOk = 0,
++  kBadArgs = 2,
++  kCannotOpenPayload = 3,
++  kVerificationFailed = 4,
++  kInstallLaunchFailed = 5,
++  kInstallFailed = 6,
++  kBrowserStillRunning = 7,
++};
++
++// Writes a message to the Windows Application event log under
++// the helper source. `type` is an EVENTLOG_* severity.
++void LogEvent(WORD type, const std::wstring& message);
++
++// Reads the localized string identified by `base_message_id`
++// (an installer IDS_*_BASE id) from the embedded string table
++// for the OS UI language. Returns an empty string on failure.
++std::wstring LocalizedString(int base_message_id);
++
++// Returns true if `path` is a local, absolute, non-UNC path.
++bool IsAcceptablePayloadPath(const base::FilePath& path);
++
++// Returns true if the payload is Authenticode-trusted AND either signed by
++// Helium's organization or carrying a valid EdDSA signature.
++// - `file` is the open handle to the payload at `path`.
++// - `signature_b64` is the base64 ed25519 detached signature of `bytes`.
++bool VerifyPayload(HANDLE file,
++                   const base::FilePath& path,
++                   base::span<const uint8_t> bytes,
++                   const std::string& signature_b64);
++
++// Verifies and runs the payload (assuming the browser has already exited).
++// Returns an ExitCode, does not relaunch.
++int ApplyUpdate(const base::FilePath& payload, const std::string& signature);
++
++// Relaunches the installed chrome.exe de-elevated via the shell.
++// Returns false on failure.
++bool RelaunchBrowser();
++
++// Runs ApplyUpdate on a worker thread behind a marquee progress dialog
++// and returns its ExitCode.
++int InstallWithProgressUI(const base::FilePath& payload,
++                          const std::string& signature);
++
++// Shows a modal dialog reporting that the update failed.
++void ShowUpdateFailedDialog();
++
++}  // namespace helium_updater
++
++#endif  // CHROME_INSTALLER_HELIUM_UPDATE_HELPER_HELIUM_UPDATE_HELPER_INTERNAL_H_
+--- /dev/null
++++ b/chrome/installer/helium_update_helper/helium_update_helper_main.cc
+@@ -0,0 +1,59 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++//
++// Elevated apply helper for Helium's *system-level* auto-updates.
++// Launched by the browser when the user clicks Relaunch.
++// Args:  --payload=<mini_installer.exe>  --signature=<base64 ed25519>
++//        --wait-pid=<browser process id>
++
++#include <windows.h>
++
++#include <cstdint>
++#include <string>
++
++#include "base/at_exit.h"
++#include "base/command_line.h"
++#include "base/files/file_path.h"
++#include "base/process/process.h"
++#include "base/strings/string_number_conversions.h"
++#include "base/strings/utf_string_conversions.h"
++#include "base/time/time.h"
++#include "base/win/scoped_com_initializer.h"
++#include "chrome/installer/helium_update_helper/helium_update_helper_internal.h"
++
++namespace {
++// How long to wait for the browser to exit before applying the update.
++constexpr base::TimeDelta kBrowserExitTimeout = base::Minutes(2);
++}  // namespace
++
++int APIENTRY wWinMain(HINSTANCE, HINSTANCE, wchar_t*, int) {
++  base::AtExitManager exit_manager;
++  ::SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32);
++  base::CommandLine::Init(0, nullptr);
++
++  base::win::ScopedCOMInitializer com_initializer;
++  const base::CommandLine& command = *base::CommandLine::ForCurrentProcess();
++  const base::FilePath payload = command.GetSwitchValuePath("payload");
++  const std::string signature =
++      base::WideToUTF8(command.GetSwitchValueNative("signature"));
++
++  uint32_t pid = 0;
++  if (base::StringToUint(
++          base::WideToUTF8(command.GetSwitchValueNative("wait-pid")), &pid) &&
++      pid) {
++    base::Process browser = base::Process::Open(pid);
++    if (browser.IsValid() &&
++        !browser.WaitForExitWithTimeout(kBrowserExitTimeout, nullptr)) {
++      return helium_updater::kBrowserStillRunning;
++    }
++  }
++
++  const int result = helium_updater::InstallWithProgressUI(payload, signature);
++  if (result != helium_updater::kOk) {
++    helium_updater::ShowUpdateFailedDialog();
++  }
++
++  helium_updater::RelaunchBrowser();
++  return result;
++}
+--- /dev/null
++++ b/chrome/installer/helium_update_helper/localized_strings.cc
+@@ -0,0 +1,63 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include <windows.h>
++
++#include <cstdint>
++
++#include "base/containers/buffer_iterator.h"
++#include "base/containers/span.h"
++#include "base/no_destructor.h"
++#include "base/win/current_module.h"
++#include "base/win/embedded_i18n/language_selector.h"
++#include "chrome/installer/helium_update_helper/helium_update_helper_internal.h"
++#include "chrome/installer/util/installer_util_strings.h"
++
++namespace helium_updater {
++
++namespace {
++constexpr base::win::i18n::LanguageSelector::LangToOffset kLanguageOffsets[] = {
++#define HANDLE_LANGUAGE(l_, o_) {L## #l_, o_},
++    DO_LANGUAGES
++#undef HANDLE_LANGUAGE
++};
++}  // namespace
++
++std::wstring LocalizedString(int base_message_id) {
++  static base::NoDestructor<base::win::i18n::LanguageSelector> selector(
++      std::wstring_view(), kLanguageOffsets);
++  const UINT message_id = static_cast<UINT>(base_message_id) +
++                          static_cast<UINT>(selector->offset());
++  const WORD bundle_id = static_cast<WORD>((message_id >> 4) + 1);
++  HRSRC res =
++      ::FindResourceW(CURRENT_MODULE(), MAKEINTRESOURCEW(bundle_id), RT_STRING);
++  if (!res) {
++    return std::wstring();
++  }
++
++  HGLOBAL data = ::LoadResource(CURRENT_MODULE(), res);
++  const auto* bytes =
++      data ? static_cast<const uint8_t*>(::LockResource(data)) : nullptr;
++  if (!bytes) {
++    return std::wstring();
++  }
++
++  base::BufferIterator<const uint8_t> it(base::span(
++      bytes, static_cast<size_t>(::SizeofResource(CURRENT_MODULE(), res))));
++  for (UINT i = message_id & 0xF; i; --i) {
++    if (const auto* length = it.Object<const WORD>()) {
++      it.Span<wchar_t>(*length);
++    }
++  }
++
++  if (const auto* length = it.Object<const WORD>(); length && *length) {
++    if (auto str = it.Span<wchar_t>(*length); !str.empty()) {
++      return std::wstring(str.data(), *length);
++    }
++  }
++
++  return std::wstring();
++}
++
++}  // namespace helium_updater
+--- /dev/null
++++ b/chrome/installer/helium_update_helper/payload_verifier.cc
+@@ -0,0 +1,118 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include <windows.h>
++
++#include <softpub.h>
++#include <wincrypt.h>
++#include <wintrust.h>
++
++#include <iterator>
++#include <utility>
++
++#include "base/base64.h"
++#include "base/strings/string_util_win.h"
++#include "base/strings/stringprintf.h"
++#include "base/strings/utf_string_conversions.h"
++#include "chrome/installer/helium_update_helper/helium_update_helper_internal.h"
++#include "third_party/boringssl/src/include/openssl/curve25519.h"
++
++namespace helium_updater {
++
++namespace {
++
++bool SignerOrgMatches(PCCERT_CONTEXT cert) {
++  wchar_t org[std::size(HELIUM_AUTHENTICODE_ORG) + 1] = {};
++  ::CertGetNameStringW(cert, CERT_NAME_ATTR_TYPE, 0,
++                       const_cast<char*>(szOID_ORGANIZATION_NAME), org,
++                       std::size(org));
++  return base::EqualsCaseInsensitiveASCII(org, HELIUM_AUTHENTICODE_ORG);
++}
++
++std::pair<bool, bool> VerifyAuthenticode(HANDLE file,
++                                         const std::wstring& path) {
++  WINTRUST_FILE_INFO file_info = {sizeof(file_info)};
++  file_info.pcwszFilePath = path.c_str();
++  if (file != INVALID_HANDLE_VALUE) {
++    ::SetFilePointer(file, 0, nullptr, FILE_BEGIN);
++  }
++  file_info.hFile = file;
++
++  WINTRUST_DATA data = {sizeof(data)};
++  data.dwUIChoice = WTD_UI_NONE;
++  data.fdwRevocationChecks = WTD_REVOKE_WHOLECHAIN;
++  data.dwUnionChoice = WTD_CHOICE_FILE;
++  data.pFile = &file_info;
++  data.dwStateAction = WTD_STATEACTION_VERIFY;
++  data.dwProvFlags = WTD_REVOCATION_CHECK_CHAIN;
++
++  GUID action = WINTRUST_ACTION_GENERIC_VERIFY_V2;
++  const HWND kNoUi = reinterpret_cast<HWND>(INVALID_HANDLE_VALUE);
++  const LONG status = ::WinVerifyTrust(kNoUi, &action, &data);
++  const bool trusted = status == ERROR_SUCCESS;
++  bool org_matches = false;
++
++  if (trusted) {
++    CRYPT_PROVIDER_DATA* prov =
++        WTHelperProvDataFromStateData(data.hWVTStateData);
++    CRYPT_PROVIDER_SGNR* sgnr =
++        prov ? WTHelperGetProvSignerFromChain(prov, 0, FALSE, 0) : nullptr;
++    CRYPT_PROVIDER_CERT* cert = (sgnr && sgnr->csCertChain > 0)
++                                    ? WTHelperGetProvCertFromChain(sgnr, 0)
++                                    : nullptr;
++    if (cert && cert->pCert) {
++      org_matches = SignerOrgMatches(cert->pCert);
++    }
++  } else {
++    const DWORD last_error = ::GetLastError();
++    LogEvent(EVENTLOG_ERROR_TYPE,
++             base::UTF8ToWide(base::StringPrintf(
++                 "Authenticode check failed: status=0x%08lX last_error=0x%08lX",
++                 status, last_error)));
++  }
++
++  data.dwStateAction = WTD_STATEACTION_CLOSE;
++  ::WinVerifyTrust(kNoUi, &action, &data);
++  return {trusted, org_matches};
++}
++
++bool VerifyEdDSA(base::span<const uint8_t> payload,
++                 const std::string& signature_b64) {
++  std::string signature;
++  std::string pubkey;
++  if (!base::Base64Decode(signature_b64, &signature) ||
++      !base::Base64Decode(HELIUM_EDDSA_PUBKEY, &pubkey)) {
++    return false;
++  }
++
++  if (signature.size() != 64 || pubkey.size() != 32 || payload.empty()) {
++    return false;
++  }
++
++  return ED25519_verify(payload.data(), payload.size(),
++                        reinterpret_cast<const uint8_t*>(signature.data()),
++                        reinterpret_cast<const uint8_t*>(pubkey.data())) == 1;
++}
++
++}  // namespace
++
++bool IsAcceptablePayloadPath(const base::FilePath& path) {
++  return !path.empty() && path.IsAbsolute() && !path.IsNetwork();
++}
++
++bool VerifyPayload(HANDLE file,
++                   const base::FilePath& path,
++                   base::span<const uint8_t> bytes,
++                   const std::string& signature_b64) {
++  auto [trusted, org_matches] = VerifyAuthenticode(file, path.value());
++  if (!trusted) {
++    return false;
++  }
++
++  // Either O= must match expectations, or the EdDSA signature check must pass.
++  // This is to allow rotating either component (similarly to Sparkle on Mac).
++  return org_matches || VerifyEdDSA(bytes, signature_b64);
++}
++
++}  // namespace helium_updater
+--- /dev/null
++++ b/chrome/installer/helium_update_helper/progress_dialog.cc
+@@ -0,0 +1,108 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include <windows.h>
++
++#include <commctrl.h>
++
++#include <atomic>
++#include <utility>
++
++#include "base/threading/simple_thread.h"
++#include "chrome/installer/helium_update_helper/helium_update_helper_internal.h"
++#include "chrome/installer/util/installer_util_strings.h"
++
++namespace helium_updater {
++
++namespace {
++
++class InstallJob : public base::DelegateSimpleThread::Delegate {
++ public:
++  InstallJob(base::FilePath payload, std::string signature)
++      : payload_(std::move(payload)), signature_(std::move(signature)) {}
++
++  void Run() override {
++    result_.store(ApplyUpdate(payload_, signature_), std::memory_order_release);
++    done_.store(true, std::memory_order_release);
++  }
++
++  bool done() const { return done_.load(std::memory_order_acquire); }
++  int result() const { return result_.load(std::memory_order_acquire); }
++
++ private:
++  const base::FilePath payload_;
++  const std::string signature_;
++  std::atomic<bool> done_{false};
++  std::atomic<int> result_{kInstallFailed};
++};
++
++HRESULT CALLBACK ProgressDialogCallback(HWND hwnd,
++                                        UINT msg,
++                                        WPARAM wparam,
++                                        LPARAM lparam,
++                                        LONG_PTR data) {
++  auto* job = reinterpret_cast<InstallJob*>(data);
++  switch (msg) {
++    case TDN_CREATED:
++      ::SendMessageW(hwnd, TDM_SET_PROGRESS_BAR_MARQUEE, TRUE, 30);
++      // The install can't be safely interrupted; the Cancel button exists only
++      // as the handle we use to close the dialog, so show it disabled.
++      ::SendMessageW(hwnd, TDM_ENABLE_BUTTON, IDCANCEL, FALSE);
++      break;
++    case TDN_TIMER:
++      if (job->done()) {
++        ::SendMessageW(hwnd, TDM_ENABLE_BUTTON, IDCANCEL, TRUE);
++        ::SendMessageW(hwnd, TDM_CLICK_BUTTON, IDCANCEL, 0);
++      }
++      break;
++    case TDN_BUTTON_CLICKED:
++      // Esc and the title-bar close also map to Cancel; block them until done.
++      if (wparam == IDCANCEL && !job->done()) {
++        return S_FALSE;
++      }
++      break;
++  }
++  return S_OK;
++}
++
++}  // namespace
++
++int InstallWithProgressUI(const base::FilePath& payload,
++                          const std::string& signature) {
++  InstallJob job(payload, signature);
++  base::DelegateSimpleThread thread(&job, "HeliumInstall");
++  thread.Start();
++
++  const std::wstring title = LocalizedString(IDS_PRODUCT_NAME_BASE);
++  const std::wstring instruction = LocalizedString(IDS_INSTALLING_BASE);
++
++  TASKDIALOGCONFIG config = {};
++  config.cbSize = sizeof(config);
++  config.dwFlags = TDF_SHOW_MARQUEE_PROGRESS_BAR | TDF_CALLBACK_TIMER;
++  config.dwCommonButtons = TDCBF_CANCEL_BUTTON;  // disabled; close handle only
++  config.pszWindowTitle = title.c_str();
++  config.pszMainInstruction = instruction.c_str();
++  config.pfCallback = &ProgressDialogCallback;
++  config.lpCallbackData = reinterpret_cast<LONG_PTR>(&job);
++  ::TaskDialogIndirect(&config, nullptr, nullptr, nullptr);
++
++  thread.Join();
++  return job.result();
++}
++
++void ShowUpdateFailedDialog() {
++  const std::wstring title = LocalizedString(IDS_PRODUCT_NAME_BASE);
++  const std::wstring message = LocalizedString(IDS_INSTALL_FAILED_BASE);
++
++  TASKDIALOGCONFIG config = {};
++  config.cbSize = sizeof(config);
++  config.dwFlags = TDF_ALLOW_DIALOG_CANCELLATION;
++  config.dwCommonButtons = TDCBF_OK_BUTTON;
++  config.pszWindowTitle = title.c_str();
++  config.pszMainIcon = TD_ERROR_ICON;
++  config.pszMainInstruction = message.c_str();
++  ::TaskDialogIndirect(&config, nullptr, nullptr, nullptr);
++}
++
++}  // namespace helium_updater
+--- /dev/null
++++ b/chrome/installer/helium_update_helper/update_installer.cc
+@@ -0,0 +1,111 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include <windows.h>
++
++#include <cstdint>
++#include <vector>
++
++#include "base/base_paths.h"
++#include "base/command_line.h"
++#include "base/containers/span.h"
++#include "base/files/file.h"
++#include "base/path_service.h"
++#include "base/process/launch.h"
++#include "base/process/process.h"
++#include "base/strings/strcat_win.h"
++#include "base/strings/string_number_conversions_win.h"
++#include "base/win/elevation_util.h"
++#include "chrome/installer/helium_update_helper/helium_update_helper_internal.h"
++
++namespace helium_updater {
++
++namespace {
++
++// Upper bound on the update payload we'll read into memory. The mini_installer
++// is hundred to a few hundred MB; reject anything beyond 512 MiB as bogus.
++constexpr int64_t kMaxPayloadBytes = int64_t{512} * 1024 * 1024;
++
++base::FilePath InstalledChromeExe() {
++  base::FilePath exe;
++  if (!base::PathService::Get(base::FILE_EXE, &exe)) {
++    return base::FilePath();
++  }
++  return exe.DirName().DirName().Append(FILE_PATH_LITERAL("chrome.exe"));
++}
++
++}  // namespace
++
++int ApplyUpdate(const base::FilePath& payload, const std::string& signature) {
++  if (!IsAcceptablePayloadPath(payload)) {
++    LogEvent(EVENTLOG_ERROR_TYPE,
++             L"Payload path missing or not a local absolute path");
++    return kBadArgs;
++  }
++
++  base::File file(payload, base::File::FLAG_OPEN | base::File::FLAG_READ |
++                               base::File::FLAG_WIN_EXCLUSIVE_WRITE);
++  if (!file.IsValid()) {
++    LogEvent(EVENTLOG_ERROR_TYPE, L"Cannot open payload.");
++    return kCannotOpenPayload;
++  }
++
++  const int64_t length = file.GetLength();
++  if (length <= 0 || length > kMaxPayloadBytes) {
++    LogEvent(EVENTLOG_ERROR_TYPE, L"Payload too large or unreadable.");
++    return kCannotOpenPayload;
++  }
++
++  std::vector<uint8_t> bytes(static_cast<size_t>(length));
++  if (!file.ReadAndCheck(0, base::span(bytes))) {
++    LogEvent(EVENTLOG_ERROR_TYPE, L"Cannot read payload.");
++    return kCannotOpenPayload;
++  }
++
++  if (!VerifyPayload(file.GetPlatformFile(), payload, bytes, signature)) {
++    LogEvent(EVENTLOG_ERROR_TYPE,
++             L"Payload failed verification; refusing to install.");
++    return kVerificationFailed;
++  }
++
++  // Run the installer. The browser has exited, so this is a clean install
++  // (new version dir + rename), no deferral.
++  base::CommandLine command(payload);
++  command.AppendSwitch("system-level");
++  command.AppendSwitch("do-not-launch-chrome");
++  base::LaunchOptions options;
++  options.start_hidden = true;
++  base::Process installer = base::LaunchProcess(command, options);
++  if (!installer.IsValid()) {
++    LogEvent(EVENTLOG_ERROR_TYPE, L"Failed to launch installer.");
++    return kInstallLaunchFailed;
++  }
++
++  int exit_code = -1;
++  if (!installer.WaitForExit(&exit_code) || exit_code != 0) {
++    LogEvent(EVENTLOG_ERROR_TYPE,
++             base::StrCat({L"Installer reported failure, exit code ",
++                           base::NumberToWString(exit_code)}));
++    return kInstallFailed;
++  }
++
++  LogEvent(EVENTLOG_INFORMATION_TYPE, L"System update installed.");
++  return kOk;
++}
++
++bool RelaunchBrowser() {
++  const base::FilePath chrome_exe = InstalledChromeExe();
++  if (chrome_exe.empty()) {
++    return false;
++  }
++  const HRESULT hr = base::win::RunDeElevatedNoWait(chrome_exe.value(),
++                                                    L"--restore-last-session");
++  if (FAILED(hr)) {
++    LogEvent(EVENTLOG_WARNING_TYPE, L"Relaunch via shell failed.");
++    return false;
++  }
++  return true;
++}
++
++}  // namespace helium_updater
+--- a/chrome/installer/mini_installer/chrome.release
++++ b/chrome/installer/mini_installer/chrome.release
+@@ -26,6 +26,7 @@ chrome_pwa_launcher.exe: %(VersionDir)s\
+ chrome_wer.dll: %(VersionDir)s\
+ d3dcompiler_47.dll: %(VersionDir)s\
+ eventlog_provider.dll: %(VersionDir)s\
++helium_update_helper.exe: %(VersionDir)s\
+ icudtl.dat: %(VersionDir)s\
+ libEGL.dll: %(VersionDir)s\
+ libGLESv2.dll: %(VersionDir)s\
+--- a/chrome/installer/util/prebuild/create_installer_string_rc.py
++++ b/chrome/installer/util/prebuild/create_installer_string_rc.py
+@@ -14,6 +14,7 @@ STRING_IDS = [
+   'IDS_ELEVATION_SERVICE_DESCRIPTION',
+   'IDS_INBOUND_MDNS_RULE_DESCRIPTION',
+   'IDS_INBOUND_MDNS_RULE_NAME',
++  'IDS_INSTALLING',
+   'IDS_INSTALL_EXISTING_VERSION_LAUNCHED',
+   'IDS_INSTALL_FAILED',
+   'IDS_INSTALL_HIGHER_VERSION',
+--- a/chrome/tools/build/win/FILES.cfg
++++ b/chrome/tools/build/win/FILES.cfg
+@@ -85,6 +85,13 @@ FILES = [
+     'optional': ['dev', 'official'],
+   },
+   {
++    # Helium elevated SYSTEM-side update applier (system-level installs only).
++    'filename': 'helium_update_helper.exe',
++    'buildtype': ['dev', 'official'],
++    'filegroup': ['default'],
++    'optional': ['dev', 'official'],
++  },
++  {
+     'filename': '*.manifest',
+     'buildtype': ['official'],
+     'filegroup': ['default'],
+--- a/infra/archive_config/win-archive-rel.json
++++ b/infra/archive_config/win-archive-rel.json
+@@ -17,6 +17,7 @@
+                 "elevation_service.exe",
+                 "eventlog_provider.dll",
+                 "First Run",
++                "helium_update_helper.exe",
+                 "icudtl.dat",
+                 "interactive_ui_tests.exe",
+                 "IwaKeyDistribution\\iwa-key-distribution.pb",

--- a/patches/helium/windows/updater/helper.patch
+++ b/patches/helium/windows/updater/helper.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -5851,6 +5851,7 @@ static_library("browser") {
+@@ -4086,6 +4086,7 @@ static_library("browser") {
          "//components/helium_services",
          "//third_party/winsparkle",
        ]

--- a/patches/helium/windows/updater/register.patch
+++ b/patches/helium/windows/updater/register.patch
@@ -1,0 +1,70 @@
+--- a/chrome/browser/chrome_browser_main_win.cc
++++ b/chrome/browser/chrome_browser_main_win.cc
+@@ -135,6 +135,10 @@
+ #include "chrome/browser/platform_experience/installer/installer_win.h"
+ #endif  // BUILDFLAG(GOOGLE_CHROME_BRANDING)
+ 
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++#include "chrome/browser/win/winsparkle_glue.h"
++#endif  // BUILDFLAG(ENABLE_WINSPARKLE)
++
+ namespace {
+ 
+ typedef HRESULT (STDAPICALLTYPE* RegisterApplicationRestartProc)(
+@@ -640,6 +644,10 @@ void ChromeBrowserMainPartsWin::PostProf
+   if (!is_initial_profile)
+     return;
+ 
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++  helium::InitializeWinSparkle(profile);
++#endif
++
+   // If Chrome was launched by a Progressive Web App launcher that needs to be
+   // updated, update all launchers for this profile.
+   if (base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kAppId) &&
+--- a/chrome/browser/lifetime/application_lifetime_desktop.cc
++++ b/chrome/browser/lifetime/application_lifetime_desktop.cc
+@@ -17,6 +17,7 @@
+ #include "chrome/browser/background/glic/glic_background_mode_manager.h"
+ #include "chrome/browser/browser_process.h"
+ #include "chrome/browser/browser_process_platform_part.h"
++#include "chrome/browser/buildflags.h"
+ #include "chrome/browser/download/download_core_service.h"
+ #include "chrome/browser/lifetime/application_lifetime.h"
+ #include "chrome/browser/lifetime/browser_close_manager.h"
+@@ -50,6 +51,10 @@
+ #include "base/win/win_util.h"
+ #endif  // BUILDFLAG(IS_WIN)
+ 
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++#include "chrome/browser/win/winsparkle_glue.h"
++#endif  // BUILDFLAG(ENABLE_WINSPARKLE)
++
+ #if BUILDFLAG(ENABLE_SESSION_SERVICE)
+ #include "chrome/browser/sessions/session_data_service.h"
+ #include "chrome/browser/sessions/session_data_service_factory.h"
+@@ -109,9 +114,21 @@ void AttemptRestartInternal(IgnoreUnload
+   content::GetUIThreadTaskRunner({})->PostTask(
+       FROM_HERE, base::BindOnce(&ExitIgnoreUnloadHandlers));
+ #else   // !BUILDFLAG(IS_CHROMEOS).
+-
+-  pref_service->SetBoolean(prefs::kRestartLastSessionOnShutdown, true);
+-
++  // Set the flag to restore state after the restart.
++  bool self_relaunch = true;
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++  // If a system-level update is downloaded and waiting, we raise a
++  // UAC prompt when the user clicks Relaunch, and hand off to the
++  // elevated apply helper, which waits for this process to exit,
++  // and relaunches the browser itself. In that case we do not want
++  // the normal self-relaunch.
++  if (helium::MaybeElevateSystemUpdateOnRelaunch()) {
++    self_relaunch = false;
++  }
++#endif
++  if (self_relaunch) {
++    pref_service->SetBoolean(prefs::kRestartLastSessionOnShutdown, true);
++  }
+   if (ignore_unload_handlers) {
+     ExitIgnoreUnloadHandlers();
+   } else {

--- a/patches/helium/windows/updater/register.patch
+++ b/patches/helium/windows/updater/register.patch
@@ -43,14 +43,11 @@
  #if BUILDFLAG(ENABLE_SESSION_SERVICE)
  #include "chrome/browser/sessions/session_data_service.h"
  #include "chrome/browser/sessions/session_data_service_factory.h"
-@@ -109,9 +114,21 @@ void AttemptRestartInternal(IgnoreUnload
-   content::GetUIThreadTaskRunner({})->PostTask(
+@@ -113,7 +118,21 @@ void AttemptRestartInternal(IgnoreUnload
        FROM_HERE, base::BindOnce(&ExitIgnoreUnloadHandlers));
  #else   // !BUILDFLAG(IS_CHROMEOS).
--
+   // Set the flag to restore state after the restart.
 -  pref_service->SetBoolean(prefs::kRestartLastSessionOnShutdown, true);
--
-+  // Set the flag to restore state after the restart.
 +  bool self_relaunch = true;
 +#if BUILDFLAG(ENABLE_WINSPARKLE)
 +  // If a system-level update is downloaded and waiting, we raise a
@@ -65,6 +62,7 @@
 +  if (self_relaunch) {
 +    pref_service->SetBoolean(prefs::kRestartLastSessionOnShutdown, true);
 +  }
++
    if (ignore_unload_handlers) {
      ExitIgnoreUnloadHandlers();
    } else {

--- a/patches/helium/windows/updater/update-notifications.patch
+++ b/patches/helium/windows/updater/update-notifications.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/upgrade_detector/get_installed_version_win.cc
 +++ b/chrome/browser/upgrade_detector/get_installed_version_win.cc
-@@ -11,10 +11,51 @@
+@@ -11,10 +11,77 @@
  #include "base/location.h"
  #include "base/task/task_traits.h"
  #include "base/task/thread_pool.h"
@@ -9,13 +9,19 @@
 +#if BUILDFLAG(ENABLE_WINSPARKLE)
 +#include <windows.h>
 +
++#include <string>
 +#include <vector>
 +
 +#include "base/base_paths.h"
 +#include "base/files/file_path.h"
++#include "base/files/file_util.h"
 +#include "base/path_service.h"
++#include "base/process/process.h"
++#include "base/strings/string_number_conversions.h"
++#include "base/time/time.h"
 +#include "base/version.h"
 +#include "base/version_info/version_info.h"
++#include "chrome/common/chrome_paths.h"
 +#include "chrome/installer/util/util_constants.h"
 +#else
  #include "chrome/installer/util/install_util.h"
@@ -37,9 +43,29 @@
 +         INVALID_FILE_ATTRIBUTES;
 +}
 +
++// System installs can't stage without elevation, so the glue drops a
++// marker holding the process's creation time, so any prior sessions
++// are ignored, and quit-without-relaunch doesn't leave a stale chip.
++bool HasPendingSystemUpdate() {
++  base::FilePath user_data;
++  if (!base::PathService::Get(chrome::DIR_USER_DATA, &user_data)) {
++    return false;
++  }
++  std::string token;
++  if (!base::ReadFileToString(
++          user_data.Append(FILE_PATH_LITERAL("PendingSystemUpdate")), &token)) {
++    return false;
++  }
++  return token == base::NumberToString(base::Process::Current()
++                                           .CreationTime()
++                                           .ToDeltaSinceWindowsEpoch()
++                                           .InMicroseconds());
++}
++
 +InstalledAndCriticalVersion GetInstalledVersionSynchronous() {
 +  base::Version running = version_info::GetVersion();
-+  if (HasPendingUpdateSwap() && running.IsValid()) {
++  if ((HasPendingUpdateSwap() || HasPendingSystemUpdate()) &&
++      running.IsValid()) {
 +    std::vector<uint32_t> components = running.components();
 +    components.back() += 1;
 +    return InstalledAndCriticalVersion(base::Version(std::move(components)));
@@ -52,7 +78,7 @@
  InstalledAndCriticalVersion GetInstalledVersionSynchronous() {
    base::Version installed_version =
        InstallUtil::GetChromeVersion(!InstallUtil::IsPerUserInstall());
-@@ -28,6 +69,8 @@ InstalledAndCriticalVersion GetInstalled
+@@ -28,6 +95,8 @@ InstalledAndCriticalVersion GetInstalled
    return InstalledAndCriticalVersion(std::move(installed_version));
  }
  
@@ -61,21 +87,3 @@
  }  // namespace
  
  void GetInstalledVersion(InstalledVersionCallback callback) {
---- a/chrome/installer/setup/last_breaking_installer_version.cc
-+++ b/chrome/installer/setup/last_breaking_installer_version.cc
-@@ -11,12 +11,8 @@ namespace installer {
- // When updating the documentation, keep a history of maximum 3 milestones prior
- // the current version because downgrades are supported for 3 milestones.
- //
--// Breaking changes from 85.0.4169.0:
--//  Change: Default installation directory for fresh 64 bits browsers moved from
--//    base::DIR_PROGRAM_FILESX86 to DIR_PROGRAM_FILES.
--//  Reason for being breaking: Downgrading to previous version will result in
--//    stale data in DIR_PROGRAM_FILES since the previous installers do not know
--//    if there is Chrome data at this location.
--const wchar_t kLastBreakingInstallerVersion[] = L"85.0.4169.0";
-+// Helium uses its own version scheme, which is below every Chromium
-+// "breaking installer version".
-+const wchar_t kLastBreakingInstallerVersion[] = L"0.0.0.0";
- 
- }  // namespace installer

--- a/patches/helium/windows/updater/winsparkle-api-extensions.patch
+++ b/patches/helium/windows/updater/winsparkle-api-extensions.patch
@@ -1,0 +1,254 @@
+--- a/third_party/winsparkle/include/winsparkle.h
++++ b/third_party/winsparkle/include/winsparkle.h
+@@ -400,6 +400,35 @@ WIN_SPARKLE_API int __cdecl win_sparkle_
+ */
+ WIN_SPARKLE_API time_t __cdecl win_sparkle_get_last_check_time();
+ 
++/**
++    Returns the EdDSA signature (base64) of the update currently pending
++    installation -- the same payload passed to the user-run-installer callback.
++
++    @param buf      Buffer to receive the NUL-terminated base64 signature.
++    @param buf_len  Size of @a buf, in chars (including room for the NUL).
++
++    @return Number of characters written (excluding the NUL), or 0 if there is
++            no pending signature or @a buf is NULL / too small.
++ */
++WIN_SPARKLE_API size_t __cdecl win_sparkle_get_pending_update_eddsa_signature(
++    char* buf,
++    size_t buf_len);
++
++/**
++    Returns a human-readable description of the most recent update error (the
++    error callback itself carries no detail), e.g. "Update download failed:
++    Cannot save update file."
++
++    @param buf      Buffer to receive the NUL-terminated UTF-8 message.
++    @param buf_len  Size of @a buf, in chars (including room for the NUL).
++
++    @return Number of characters written (excluding the NUL), or 0 if there is
++            no message or @a buf is NULL / too small.
++ */
++WIN_SPARKLE_API size_t __cdecl win_sparkle_get_last_error_message(
++    char* buf,
++    size_t buf_len);
++
+ /// Callback type for win_sparkle_error_callback()
+ typedef void (__cdecl *win_sparkle_error_callback_t)();
+ 
+@@ -580,6 +609,15 @@ typedef int(__cdecl* win_sparkle_user_ru
+ */
+ WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_sparkle_user_run_installer_callback_t callback);
+ 
++/// Callback type for win_sparkle_set_download_progress_callback().
++/// @a downloaded and @a total are byte counts; @a total is 0 if unknown.
++typedef void(__cdecl* win_sparkle_download_progress_callback_t)(
++    size_t downloaded,
++    size_t total);
++
++WIN_SPARKLE_API void __cdecl win_sparkle_set_download_progress_callback(
++    win_sparkle_download_progress_callback_t callback);
++
+ //@}
+ 
+ 
+--- a/third_party/winsparkle/src/appcontroller.cpp
++++ b/third_party/winsparkle/src/appcontroller.cpp
+@@ -41,6 +41,11 @@ win_sparkle_update_skipped_callback_t
+ win_sparkle_update_postponed_callback_t    ApplicationController::ms_cbUpdatePostponed = NULL;
+ win_sparkle_update_dismissed_callback_t    ApplicationController::ms_cbUpdateDismissed = NULL;
+ win_sparkle_user_run_installer_callback_t  ApplicationController::ms_cbUserRunInstaller = NULL;
++win_sparkle_download_progress_callback_t   ApplicationController::ms_cbDownloadProgress = NULL;
++
++std::string ApplicationController::ms_pendingEdDsaSignature;
++
++std::string ApplicationController::ms_lastUpdateError;
+ 
+ bool ApplicationController::IsReadyToShutdown()
+ {
+@@ -164,4 +169,37 @@ int ApplicationController::UserRunInstal
+     return ms_cbUserRunInstaller(filePath);
+ }
+ 
++void ApplicationController::NotifyDownloadProgress(size_t downloaded,
++                                                   size_t total) {
++  win_sparkle_download_progress_callback_t cb = NULL;
++  {
++    CriticalSectionLocker lock(ms_csVars);
++    cb = ms_cbDownloadProgress;
++  }
++  if (cb) {
++    cb(downloaded, total);
++  }
++}
++
++void ApplicationController::SetPendingUpdateEdDsaSignature(
++    const std::string& signature) {
++  CriticalSectionLocker lock(ms_csVars);
++  ms_pendingEdDsaSignature = signature;
++}
++
++std::string ApplicationController::GetPendingUpdateEdDsaSignature() {
++  CriticalSectionLocker lock(ms_csVars);
++  return ms_pendingEdDsaSignature;
++}
++
++void ApplicationController::SetLastUpdateError(const std::string& message) {
++  CriticalSectionLocker lock(ms_csVars);
++  ms_lastUpdateError = message;
++}
++
++std::string ApplicationController::GetLastUpdateError() {
++  CriticalSectionLocker lock(ms_csVars);
++  return ms_lastUpdateError;
++}
++
+ } // namespace winsparkle
+--- a/third_party/winsparkle/src/appcontroller.h
++++ b/third_party/winsparkle/src/appcontroller.h
+@@ -29,6 +29,7 @@
+ #include "winsparkle.h"
+ #include "threads.h"
+ 
++#include <string>
+ 
+ namespace winsparkle
+ {
+@@ -81,6 +82,9 @@ public:
+     /// Run the user installer callback if one is set.
+     static int UserRunInstallerCallback(const wchar_t*);
+ 
++    /// Notify of update-download progress.
++    static void NotifyDownloadProgress(size_t downloaded, size_t total);
++
+     //@}
+ 
+     /**
+@@ -157,6 +161,25 @@ public:
+         ms_cbUserRunInstaller = callback;
+     }
+ 
++    static void SetDownloadProgressCallback(win_sparkle_download_progress_callback_t callback)
++    {
++        CriticalSectionLocker lock(ms_csVars);
++        ms_cbDownloadProgress = callback;
++    }
++
++    //@}
++
++    /**
++        Pending update metadata.
++     */
++    //@{
++
++    static void SetPendingUpdateEdDsaSignature(const std::string& signature);
++    static std::string GetPendingUpdateEdDsaSignature();
++
++    static void SetLastUpdateError(const std::string& message);
++    static std::string GetLastUpdateError();
++
+     //@}
+ 
+ private:
+@@ -175,7 +198,10 @@ private:
+     static win_sparkle_update_postponed_callback_t    ms_cbUpdatePostponed;
+     static win_sparkle_update_dismissed_callback_t    ms_cbUpdateDismissed;
+     static win_sparkle_user_run_installer_callback_t  ms_cbUserRunInstaller;
++    static win_sparkle_download_progress_callback_t   ms_cbDownloadProgress;
+     
++    static std::string ms_pendingEdDsaSignature;
++    static std::string ms_lastUpdateError;
+ };
+ 
+ } // namespace winsparkle
+--- a/third_party/winsparkle/src/dll_api.cpp
++++ b/third_party/winsparkle/src/dll_api.cpp
+@@ -299,6 +299,51 @@ WIN_SPARKLE_API time_t __cdecl win_spark
+     return DEFAULT_LAST_CHECK_TIME;
+ }
+ 
++WIN_SPARKLE_API size_t __cdecl win_sparkle_get_pending_update_eddsa_signature(
++    char* buf,
++    size_t buf_len) {
++  if (buf == NULL) {
++    return 0;
++  }
++
++  try {
++    const std::string sig =
++        ApplicationController::GetPendingUpdateEdDsaSignature();
++    if (sig.empty() || buf_len <= sig.size()) {
++      return 0;
++    }
++
++    sig.copy(buf, sig.size());
++    buf[sig.size()] = '\0';
++    return sig.size();
++  }
++  CATCH_ALL_EXCEPTIONS
++
++  return 0;
++}
++
++WIN_SPARKLE_API size_t __cdecl win_sparkle_get_last_error_message(
++    char* buf,
++    size_t buf_len) {
++  if (buf == NULL) {
++    return 0;
++  }
++
++  try {
++    const std::string msg = ApplicationController::GetLastUpdateError();
++    if (msg.empty() || buf_len <= msg.size()) {
++      return 0;
++    }
++
++    msg.copy(buf, msg.size());
++    buf[msg.size()] = '\0';
++    return msg.size();
++  }
++  CATCH_ALL_EXCEPTIONS
++
++  return 0;
++}
++
+ WIN_SPARKLE_API void __cdecl win_sparkle_set_error_callback(win_sparkle_error_callback_t callback)
+ {
+     try
+@@ -429,5 +474,13 @@ WIN_SPARKLE_API void __cdecl win_sparkle
+     ApplicationController::SetUserRunInstallerCallback(callback);
+ }
+ 
++WIN_SPARKLE_API void __cdecl win_sparkle_set_download_progress_callback(
++    win_sparkle_download_progress_callback_t callback) {
++  try {
++    ApplicationController::SetDownloadProgressCallback(callback);
++  }
++  CATCH_ALL_EXCEPTIONS
++}
++
+ 
+ } // extern "C"
+--- a/third_party/winsparkle/src/updatedownloader.cpp
++++ b/third_party/winsparkle/src/updatedownloader.cpp
+@@ -199,12 +199,18 @@ void UpdateDownloader::Run()
+     catch (BadSignatureException&)
+     {
+         CleanLeftovers();  // remove potentially corrupted file
+-        UI::NotifyUpdateError(Err_BadSignature);
++        UI::NotifyUpdateError("Update signature verification failed.");
++        throw;
++    }
++    catch ( const std::exception& e )
++    {
++        UI::NotifyUpdateError(std::string("Update download failed: ") +
++                              e.what());
+         throw;
+     }
+     catch ( ... )
+     {
+-        UI::NotifyUpdateError();
++        UI::NotifyUpdateError("Update download failed with an unknown error.");
+         throw;
+     }
+ }

--- a/patches/helium/windows/updater/winsparkle-api-extensions.patch
+++ b/patches/helium/windows/updater/winsparkle-api-extensions.patch
@@ -229,6 +229,24 @@
 +
  
  } // extern "C"
+--- a/third_party/winsparkle/src/updatechecker.cpp
++++ b/third_party/winsparkle/src/updatechecker.cpp
+@@ -275,9 +275,14 @@ void UpdateChecker::PerformUpdateCheck()
+ 
+         UI::NotifyUpdateAvailable(appcast, ShouldAutomaticallyInstall());
+     }
++    catch ( const std::exception& e )
++    {
++        UI::NotifyUpdateError(std::string("Update check failed: ") + e.what());
++        throw;
++    }
+     catch ( ... )
+     {
+-        UI::NotifyUpdateError();
++        UI::NotifyUpdateError("Update check failed with an unknown error.");
+         throw;
+     }
+ }
 --- a/third_party/winsparkle/src/updatedownloader.cpp
 +++ b/third_party/winsparkle/src/updatedownloader.cpp
 @@ -199,12 +199,18 @@ void UpdateDownloader::Run()

--- a/patches/helium/windows/updater/winsparkle-drop-3rdparty-deps.patch
+++ b/patches/helium/windows/updater/winsparkle-drop-3rdparty-deps.patch
@@ -1,0 +1,285 @@
+--- a/third_party/winsparkle/src/signatureverifier.cpp
++++ b/third_party/winsparkle/src/signatureverifier.cpp
+@@ -29,12 +29,7 @@
+ #include "settings.h"
+ #include "utils.h"
+ 
+-#include <openssl/dsa.h>
+-#include <openssl/err.h>
+-#include <openssl/pem.h>
+-#include <openssl/sha.h>
+-
+-#include <ed25519.h>
++#include "third_party/boringssl/src/include/openssl/curve25519.h"
+ 
+ #include <stdexcept>
+ #include <vector>
+@@ -72,199 +67,6 @@ public:
+     }
+ };
+ 
+-class WinCryptRSAContext
+-{
+-    HCRYPTPROV handle;
+-
+-    WinCryptRSAContext(const WinCryptRSAContext &);
+-    WinCryptRSAContext &operator=(const WinCryptRSAContext &);
+-public:
+-    WinCryptRSAContext()
+-    {
+-        if (!CryptAcquireContextW(&handle, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+-            throw Win32Exception("Failed to create crypto context");
+-    }
+-
+-    ~WinCryptRSAContext()
+-    {
+-        if (!CryptReleaseContext(handle, 0))
+-            LogError("Failed to release crypto context");
+-    }
+-
+-    operator HCRYPTPROV()
+-    {
+-        return handle;
+-    }
+-};
+-
+-class WinCryptSHA1Hash
+-{
+-    HCRYPTHASH handle;
+-
+-    WinCryptSHA1Hash(const WinCryptSHA1Hash&);
+-    WinCryptSHA1Hash& operator=(const WinCryptSHA1Hash &);
+-public:
+-    WinCryptSHA1Hash(WinCryptRSAContext &context)
+-    {
+-        if (!CryptCreateHash(HCRYPTPROV(context), CALG_SHA1, 0, 0, &handle))
+-            throw Win32Exception("Failed to create crypto hash");
+-    }
+-
+-    ~WinCryptSHA1Hash()
+-    {
+-        if (handle)
+-        {
+-            if (!CryptDestroyHash(handle))
+-            {
+-                LogError("Failed to destroy crypto hash");
+-            }
+-        }
+-    }
+-
+-    void hashData(const void *buffer, size_t buffer_len)
+-    {
+-        if (!CryptHashData(handle, (CONST BYTE  *)buffer, (DWORD)buffer_len, 0))
+-            throw Win32Exception("Failed to hash data");
+-    }
+-
+-    void hashFile(const std::wstring &filename)
+-    {
+-        CFile f(_wfopen(filename.c_str(), L"rb"));
+-        if (!f)
+-            throw std::runtime_error(WideToAnsi(L"Failed to open file " + filename));
+-
+-        const int BUF_SIZE = 8192;
+-        unsigned char buf[BUF_SIZE];
+-
+-        while (size_t read_bytes = fread(buf, 1, BUF_SIZE, f))
+-        {
+-            hashData(buf, read_bytes);
+-        }
+-
+-        if (ferror(f))
+-            throw std::runtime_error(WideToAnsi(L"Failed to read file " + filename));
+-    }
+-
+-    void sha1Val(unsigned char(&sha1)[SHA_DIGEST_LENGTH])
+-    {
+-        DWORD hash_len = SHA_DIGEST_LENGTH;
+-        if (!CryptGetHashParam(handle, HP_HASHVAL, sha1, &hash_len, 0))
+-            throw Win32Exception("Failed to get SHA1 val");
+-    }
+-
+-};
+-
+-/**
+-    Light-weight dynamic loader of OpenSSL library.
+-    Loads only minimum required symbols, just enough to verify DSA SHA1 signature of the file.
+- */
+-class TinySSL
+-{
+-    TinySSL() {}
+-public:
+-    static TinySSL &inst()
+-    {
+-        static TinySSL instance;
+-        return instance;
+-    }
+-
+-    ~TinySSL()
+-    {
+-    }
+-
+-    void VerifyDSASHA1Signature(const std::wstring &filename, const std::string &signature)
+-    {
+-        unsigned char sha1[SHA_DIGEST_LENGTH];
+-
+-        {
+-            WinCryptRSAContext ctx;
+-            // SHA1 of file
+-            {
+-                WinCryptSHA1Hash hash(ctx);
+-                hash.hashFile(filename);
+-                hash.sha1Val(sha1);
+-            }
+-            // SHA1 of SHA1 of file
+-            {
+-                WinCryptSHA1Hash hash(ctx);
+-                hash.hashData(sha1, ARRAYSIZE(sha1));
+-                hash.sha1Val(sha1);
+-            }
+-        }
+-
+-        DSAPub pubKey(Settings::GetDSAPubKeyPem());
+-
+-        const int code = DSA_verify(0, sha1, ARRAYSIZE(sha1), (const unsigned char*)signature.c_str(), (int)signature.size(), pubKey);
+-
+-        if (code == -1) // OpenSSL error
+-            throw BadSignatureException(ERR_error_string(ERR_get_error(), nullptr));
+-
+-        if (code != 1)
+-            throw BadSignatureException();
+-    }
+-
+-private:
+-    class BIOWrap
+-    {
+-        BIO* bio;
+-
+-        BIOWrap(const BIOWrap &);
+-        BIOWrap &operator=(const BIOWrap &);
+-
+-    public:
+-        BIOWrap(const std::string &mem_buf)
+-            : bio(BIO_new_mem_buf(mem_buf.c_str(), int(mem_buf.size())))
+-        {
+-            if (!bio)
+-                throw std::invalid_argument("Cannot set PEM key mem buffer");
+-        }
+-
+-        operator BIO*()
+-        {
+-            return bio;
+-        }
+-
+-        ~BIOWrap()
+-        {
+-            BIO_free(bio);
+-        }
+-
+-    }; // BIOWrap
+-
+-public:
+-    class DSAPub
+-    {
+-        DSA *dsa;
+-
+-        DSAPub(const DSAPub &);
+-        DSAPub &operator=(const DSAPub &);
+-
+-    public:
+-        DSAPub(const std::string &pem_key)
+-            : dsa(NULL)
+-        {
+-            BIOWrap bio(pem_key);
+-            if (!PEM_read_bio_DSA_PUBKEY(bio, &dsa, NULL, NULL))
+-            {
+-                throw std::invalid_argument("Cannot read DSA public key from PEM");
+-            }
+-        }
+-
+-        operator DSA*()
+-        {
+-            return dsa;
+-        }
+-
+-        ~DSAPub()
+-        {
+-            if (dsa)
+-                DSA_free(dsa);
+-        }
+-
+-    }; // DSAWrap
+-
+-}; // TinySSL
+-
+ std::string Base64ToBin(const std::string &base64)
+ {
+     DWORD nDestinationSize = 0;
+@@ -289,11 +91,9 @@ std::string Base64ToBin(const std::strin
+ 
+ } // anonynous
+ 
+-void SignatureVerifier::VerifyDSAPubKeyPem(const std::string &pem)
++void SignatureVerifier::VerifyDSAPubKeyPem(const std::string&)
+ {
+-    // DSAPub::DSAPub() throw if not valid
+-    TinySSL::DSAPub dsa_pub(pem);
+-    (void)dsa_pub;
++    throw BadSignatureException("DSA signatures are not supported; use EdDSA.");
+ }
+ 
+ void SignatureVerifier::VerifyEdDSAPubKey(const std::string& pubkey_base64)
+@@ -305,26 +105,9 @@ void SignatureVerifier::VerifyEdDSAPubKe
+     }
+ }
+ 
+-void SignatureVerifier::VerifyDSASHA1SignatureValid(const std::wstring &filename, const std::string &signature_base64)
++void SignatureVerifier::VerifyDSASHA1SignatureValid(const std::wstring&, const std::string&)
+ {
+-    try
+-    {
+-        if (signature_base64.size() == 0)
+-            throw BadSignatureException("Missing DSA signature!");
+-        TinySSL::inst().VerifyDSASHA1Signature(filename, Base64ToBin(signature_base64));
+-    }
+-    catch (BadSignatureException&)
+-    {
+-        throw;
+-    }
+-    catch (const std::exception &e)
+-    {
+-        throw BadSignatureException(e.what());
+-    }
+-    catch (...)
+-    {
+-        throw BadSignatureException();
+-    }
++    throw BadSignatureException("DSA signatures are not supported; use EdDSA.");
+ }
+ 
+ void SignatureVerifier::VerifyEdDSASignatureValid(const std::wstring& filename, const std::string& signature_base64)
+@@ -360,9 +143,9 @@ void SignatureVerifier::VerifyEdDSASigna
+         throw BadSignatureException("Invalid public key size.");
+     }
+ 
+-    int result = ed25519_verify(reinterpret_cast<const unsigned char*>(signature.data()),
+-                                payload.data(),
++    int result = ED25519_verify(payload.data(),
+                                 payload.size(),
++                                reinterpret_cast<const unsigned char*>(signature.data()),
+                                 reinterpret_cast<const unsigned char*>(pubkey.data()));
+     if (result != 1)
+         throw BadSignatureException();
+--- a/third_party/winsparkle/src/updatedownloader.cpp
++++ b/third_party/winsparkle/src/updatedownloader.cpp
+@@ -31,10 +31,9 @@
+ #include "error.h"
+ #include "signatureverifier.h"
+ 
+-#include <wx/string.h>
+-
+ #include <sstream>
+ #include <rpc.h>
++#include <shellapi.h>
+ #include <time.h>
+ 
+ namespace winsparkle

--- a/patches/helium/windows/updater/winsparkle-headless-ui.patch
+++ b/patches/helium/windows/updater/winsparkle-headless-ui.patch
@@ -1,0 +1,133 @@
+--- /dev/null
++++ b/third_party/winsparkle/src/ui_headless.cpp
+@@ -0,0 +1,130 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include <windows.h>
++
++#include <shellapi.h>
++
++#include <memory>
++#include <string>
++
++#include "appcast.h"
++#include "appcontroller.h"
++#include "settings.h"
++#include "threads.h"
++#include "ui.h"
++#include "updatedownloader.h"
++#include "utils.h"
++#include "winsparkle.h"
++
++namespace winsparkle {
++
++HINSTANCE UI::ms_hInstance = nullptr;
++
++namespace {
++
++CriticalSection g_downloaderCS;
++std::unique_ptr<UpdateDownloader> g_downloader;
++
++// Terminate and destroy any outstanding downloader. MUST NOT be called
++// from the downloader's own thread
++// (i.e. not from NotifyUpdateDownloaded/NotifyUpdateError).
++void StopDownloader() {
++  std::unique_ptr<UpdateDownloader> downloader;
++  {
++    CriticalSectionLocker lock(g_downloaderCS);
++    downloader = std::move(g_downloader);
++  }
++
++  if (downloader) {
++    downloader->TerminateAndJoin();
++  }
++}
++
++bool LaunchInstaller(const std::wstring& updateFile,
++                     const std::string& installerArguments) {
++  std::wstring wArgs;
++
++  SHELLEXECUTEINFO sei = {};
++  sei.cbSize = sizeof(sei);
++  sei.lpFile = updateFile.c_str();
++  sei.nShow = SW_SHOWDEFAULT;
++  sei.fMask = SEE_MASK_FLAG_NO_UI;
++
++  if (!installerArguments.empty()) {
++    wArgs = AnsiToWide(installerArguments);
++    sei.lpParameters = wArgs.c_str();
++  }
++
++  return ::ShellExecuteEx(&sei) != FALSE;
++}
++
++}  // anonymous namespace
++
++// static
++void UI::ShutDown() {
++  StopDownloader();
++}
++
++// static
++void UI::NotifyNoUpdates(bool) {
++  ApplicationController::NotifyUpdateNotFound();
++}
++
++// static
++void UI::NotifyUpdateError(const std::string& message) {
++  ApplicationController::SetLastUpdateError(message);
++  ApplicationController::NotifyUpdateError();
++}
++
++// static
++void UI::NotifyUpdateAvailable(const Appcast& info, bool) {
++  ApplicationController::NotifyUpdateFound();
++
++  if (!info.HasDownload()) {
++    return;
++  }
++
++  StopDownloader();
++  CriticalSectionLocker lock(g_downloaderCS);
++  g_downloader = std::make_unique<UpdateDownloader>(info);
++  g_downloader->Start();
++}
++
++// static
++void UI::NotifyDownloadProgress(size_t downloaded, size_t total) {
++  ApplicationController::NotifyDownloadProgress(downloaded, total);
++}
++
++// Runs in the UpdateDownloader thread context after the payload has been
++// downloaded and its EdDSA signature verified.
++// static
++void UI::NotifyUpdateDownloaded(const std::wstring& updateFile,
++                                const Appcast& appcast) {
++  ApplicationController::SetPendingUpdateEdDsaSignature(
++      appcast.enclosure.EdDsaSignature);
++
++  switch (ApplicationController::UserRunInstallerCallback(updateFile.c_str())) {
++    case 1:
++      break;
++    case WINSPARKLE_RETURN_ERROR:
++      NotifyUpdateError("the installer callback reported a failure");
++      break;
++    case 0:
++    default:
++      if (LaunchInstaller(updateFile, appcast.enclosure.InstallerArguments)) {
++        ApplicationController::RequestShutdown();
++      } else {
++        NotifyUpdateError("failed to launch the downloaded installer");
++      }
++      break;
++  }
++}
++
++// static
++void UI::ShowCheckingUpdates() {}
++// static
++void UI::AskForPermission() {}
++
++}  // namespace winsparkle

--- a/patches/helium/windows/updater/winsparkle-headless-ui.patch
+++ b/patches/helium/windows/updater/winsparkle-headless-ui.patch
@@ -1,3 +1,104 @@
+--- a/third_party/winsparkle/src/download.cpp
++++ b/third_party/winsparkle/src/download.cpp
+@@ -184,6 +184,18 @@ void WaitUntilSignaledWithTerminationChe
+     }
+ }
+ 
++std::runtime_error MakeInetError(const char *ctx, DWORD code)
++{
++    char detail[512] = {};
++    ::FormatMessageA(FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_FROM_SYSTEM |
++                         FORMAT_MESSAGE_IGNORE_INSERTS |
++                         FORMAT_MESSAGE_MAX_WIDTH_MASK,
++                     ::GetModuleHandleW(L"wininet.dll"), code, 0, detail,
++                     sizeof(detail), NULL);
++    return std::runtime_error(std::string(ctx) + " (WinINet error " +
++                              std::to_string(code) + "): " + detail);
++}
++
+ } // anonymous namespace
+ 
+ 
+@@ -202,7 +214,7 @@ void DownloadFile(const std::string& url
+     urlc.dwUrlPathLength = sizeof(url_path);
+ 
+     if ( !InternetCrackUrlA(url.c_str(), 0, ICU_DECODE, &urlc) )
+-        throw Win32Exception();
++        throw Win32Exception("InternetCrackUrl");
+ 
+     InetHandle inet = InternetOpen
+                       (
+@@ -213,7 +225,7 @@ void DownloadFile(const std::string& url
+                           INTERNET_FLAG_ASYNC // dwFlags
+                       );
+     if ( !inet )
+-        throw Win32Exception();
++        throw Win32Exception("InternetOpen");
+ 
+     DWORD dwOption = HTTP_PROTOCOL_FLAG_HTTP2;
+     InternetSetOptionW(inet, INTERNET_OPTION_ENABLE_HTTP_PROTOCOL, &dwOption, sizeof(dwOption));
+@@ -260,11 +272,14 @@ void DownloadFile(const std::string& url
+     else
+     {
+         if (GetLastError() != ERROR_IO_PENDING)
+-            throw Win32Exception();
++            throw Win32Exception("InternetOpenUrl");
+     }
+ 
+     WaitUntilSignaledWithTerminationCheck(context.eventRequestComplete, onThread);
+ 
++    if (context.lastError != ERROR_SUCCESS)
++        throw MakeInetError("update request failed", context.lastError);
++
+     // Check returned status code - we need to detect 404 instead of
+     // downloading the human-readable 404 page:
+     DWORD statusCode;
+@@ -343,7 +358,7 @@ void DownloadFile(const std::string& url
+         if (!InternetReadFileEx(conn, &ibuf, IRF_ASYNC | IRF_NO_WAIT, NULL))
+         {
+             if (GetLastError() != ERROR_IO_PENDING)
+-                throw Win32Exception();
++                throw Win32Exception("InternetReadFileEx");
+ 
+             WaitUntilSignaledWithTerminationCheck(context.eventRequestComplete, onThread);
+             continue;
+@@ -352,7 +367,7 @@ void DownloadFile(const std::string& url
+         if (ibuf.dwBufferLength == 0)
+         {
+             if (context.lastError != ERROR_SUCCESS)
+-                throw Win32Exception();
++                throw MakeInetError("download read failed", context.lastError);
+             else
+                 break; // all of the file was downloaded
+         }
+--- a/third_party/winsparkle/src/ui.h
++++ b/third_party/winsparkle/src/ui.h
+@@ -29,14 +29,10 @@
+ #include "threads.h"
+ #include "appcast.h"
+ 
+-namespace winsparkle
+-{
++#include <string>
+ 
+-enum ErrorCode
++namespace winsparkle
+ {
+-    Err_Generic,
+-    Err_BadSignature
+-};
+ 
+ /**
+     The main UI thread.
+@@ -75,7 +71,7 @@ public:
+         (i.e. the user is manually checking for updates), "update error"
+         message is shown. Otherwise, does nothing.
+      */
+-    static void NotifyUpdateError(ErrorCode err = Err_Generic);
++    static void NotifyUpdateError(const std::string& message = std::string());
+ 
+     /**
+         Notifies the UI that a new version is available.
 --- /dev/null
 +++ b/third_party/winsparkle/src/ui_headless.cpp
 @@ -0,0 +1,130 @@

--- a/patches/series
+++ b/patches/series
@@ -21,6 +21,7 @@ ungoogled-chromium/windows/windows-fix-remove-unused-preferences-fields.patch
 ungoogled-chromium/windows/windows-fix-missing-includes.patch
 
 helium/windows/change-branding.patch
+helium/windows/helium-versioning.patch
 helium/windows/setup-chromium-version-migration.patch
 
 helium/windows/updater/winsparkle-drop-3rdparty-deps.patch

--- a/patches/series
+++ b/patches/series
@@ -21,3 +21,13 @@ ungoogled-chromium/windows/windows-fix-remove-unused-preferences-fields.patch
 ungoogled-chromium/windows/windows-fix-missing-includes.patch
 
 helium/windows/change-branding.patch
+helium/windows/setup-chromium-version-migration.patch
+
+helium/windows/updater/winsparkle-drop-3rdparty-deps.patch
+helium/windows/updater/winsparkle-api-extensions.patch
+helium/windows/updater/winsparkle-headless-ui.patch
+helium/windows/updater/glue.patch
+helium/windows/updater/build-wiring.patch
+helium/windows/updater/register.patch
+helium/windows/updater/helper.patch
+helium/windows/updater/fixup-wrong-version.patch

--- a/patches/series
+++ b/patches/series
@@ -30,4 +30,4 @@ helium/windows/updater/glue.patch
 helium/windows/updater/build-wiring.patch
 helium/windows/updater/register.patch
 helium/windows/updater/helper.patch
-helium/windows/updater/fixup-wrong-version.patch
+helium/windows/updater/update-notifications.patch


### PR DESCRIPTION
for user level installs, works entirely in the background and applies update on webui "relaunch" or normal quit

for system level installs, needs elevation to apply the update, so it nags the user to apply the update by relaunching, which launches a UAC prompt

fixes #58