### PR TITLE
patches/command-ids: noop out BUILDFLAG()s

### DIFF
--- a/patches/ungoogled-chromium/windows/windows-fix-command-ids.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-command-ids.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/chrome_command_ids.h
 +++ b/chrome/app/chrome_command_ids.h
-@@ -63,11 +63,11 @@
+@@ -63,19 +63,19 @@
  #define IDC_MAXIMIZE_WINDOW             34047
  #define IDC_ALL_WINDOWS_FRONT           34048
  #define IDC_NAME_WINDOW                 34049
@@ -14,6 +14,16 @@
  #define IDC_USE_SYSTEM_TITLE_BAR        34051
  #endif
  
+-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
++#if (1)
+ #define IDC_RESTORE_WINDOW              34052
+ #endif // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
+ 
+-#if BUILDFLAG(IS_WIN)
++#if (1)
+ #define IDC_MOVE_WINDOW                 34053
+ #define IDC_SIZE_WINDOW                 34054
+ #endif // BUILDFLAG(IS_WIN)
 @@ -536,7 +536,7 @@
  #define IDC_MEDIA_ROUTER_TOGGLE_MEDIA_REMOTING 51208
  


### PR DESCRIPTION
i really thought this would Just Work but i guess not
