### PR TITLE
helium/windows: ship elevation_service.exe

### DIFF
--- a/patches/helium/windows/bundle-elevation-service.patch
+++ b/patches/helium/windows/bundle-elevation-service.patch
@@ -1,0 +1,20 @@
+--- a/chrome/installer/mini_installer/BUILD.gn
++++ b/chrome/installer/mini_installer/BUILD.gn
+@@ -191,6 +191,7 @@ action("mini_installer_archive") {
+     "//chrome:chrome_dll",
+     "//chrome/browser/extensions/default_extensions",
+     "//chrome/chrome_elf",
++    "//chrome/elevation_service",
+     "//chrome/installer/setup",
+     "//third_party/icu:icudata",
+   ]
+--- a/chrome/installer/mini_installer/chrome.release
++++ b/chrome/installer/mini_installer/chrome.release
+@@ -25,6 +25,7 @@ chrome_elf.dll: %(VersionDir)s\
+ chrome_pwa_launcher.exe: %(VersionDir)s\
+ chrome_wer.dll: %(VersionDir)s\
+ d3dcompiler_47.dll: %(VersionDir)s\
++elevation_service.exe: %(VersionDir)s\
+ eventlog_provider.dll: %(VersionDir)s\
+ icudtl.dat: %(VersionDir)s\
+ libEGL.dll: %(VersionDir)s\

--- a/patches/helium/windows/updater/build-wiring.patch
+++ b/patches/helium/windows/updater/build-wiring.patch
@@ -83,7 +83,7 @@
    }
 --- a/chrome/installer/mini_installer/chrome.release
 +++ b/chrome/installer/mini_installer/chrome.release
-@@ -36,6 +36,7 @@ vk_swiftshader.dll: %(VersionDir)s\
+@@ -37,6 +37,7 @@ vk_swiftshader.dll: %(VersionDir)s\
  vk_swiftshader_icd.json: %(VersionDir)s\
  vulkan-1.dll: %(VersionDir)s\
  v8_context_snapshot.bin: %(VersionDir)s\

--- a/patches/helium/windows/updater/helper.patch
+++ b/patches/helium/windows/updater/helper.patch
@@ -650,9 +650,9 @@
 +}  // namespace helium_updater
 --- a/chrome/installer/mini_installer/chrome.release
 +++ b/chrome/installer/mini_installer/chrome.release
-@@ -26,6 +26,7 @@ chrome_pwa_launcher.exe: %(VersionDir)s\
- chrome_wer.dll: %(VersionDir)s\
+@@ -27,6 +27,7 @@ chrome_wer.dll: %(VersionDir)s\
  d3dcompiler_47.dll: %(VersionDir)s\
+ elevation_service.exe: %(VersionDir)s\
  eventlog_provider.dll: %(VersionDir)s\
 +helium_update_helper.exe: %(VersionDir)s\
  icudtl.dat: %(VersionDir)s\

--- a/patches/series
+++ b/patches/series
@@ -23,6 +23,7 @@ ungoogled-chromium/windows/windows-fix-missing-includes.patch
 helium/windows/change-branding.patch
 helium/windows/helium-versioning.patch
 helium/windows/setup-chromium-version-migration.patch
+helium/windows/bundle-elevation-service.patch
 
 helium/windows/updater/winsparkle-drop-3rdparty-deps.patch
 helium/windows/updater/winsparkle-api-extensions.patch


### PR DESCRIPTION
it's used for app-bound encryption

https://issues.chromium.org/issues/332574912 "This is not causing any issues, if a Chromium build is shipped, the calls to the elevated service will just fail, which seems fine since Chromium doesn't offer the same security guarantees as Chrome anyway"
<img width="255" height="215" alt="Screenshot 2026-07-03 at 22 00 50" src="https://github.com/user-attachments/assets/c6a0b2d7-aa07-4d9e-92c5-ffc6bc3bbecc" />



fixes #299
